### PR TITLE
Allow variable length signing

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -202,6 +202,7 @@ The following conventions are used, with constants as defined for [https://www.s
 ** ''||'' refers to byte array concatenation.
 ** The function ''x[i:j]'', where ''x'' is a byte array and ''i, j &ge; 0'', returns a ''(j - i)''-byte array with a copy of the ''i''-th byte (inclusive) to the ''j''-th byte (exclusive) of ''x''.
 ** The function ''bytes(n, x)'', where ''x'' is an integer, returns the n-byte encoding of ''x'', most significant byte first.
+** The constant ''empty_bytestring'' refers to the empty byte array. It holds that ''len(empty_bytestring) = 0''.
 ** The function ''bytes(P)'', where ''P'' is a point for which ''not is_infinite(P)'', returns ''bytes(32, x(P))''.
 ** The function ''len(x)'' where ''x'' is a byte array returns the length of the array.
 ** The function ''has_even_y(P)'', where ''P'' is a point for which ''not is_infinite(P)'', returns ''y(P) mod 2 == 0''.
@@ -313,16 +314,22 @@ Input:
 ==== Nonce Generation ====
 
 Input:
-* The secret signing key ''sk'': a 32-byte array or 0-byte array (optional argument)
-* The aggregate public key ''aggpk'': a 32-byte array or 0-byte array (optional argument)
+* The secret signing key ''sk'': a 32-byte array (optional argument)
+* The aggregate public key ''aggpk'': a 32-byte array (optional argument)
 * The message ''m'': a byte array (optional argument)<ref name="mlen">In theory, the allowed message size is restricted because SHA256 accepts byte strings only up to size of 2^61-1 bytes (and because of the 8-byte length encoding).</ref>
 * The auxiliary input ''extra_in'': a byte array with ''0 &le; len(extra_in) &le; 2<sup>32</sup>-1'' (optional argument)
 
 '''''NonceGen(sk, aggpk, m, extra_in)''''':
 * Let ''rand' '' be a 32-byte array freshly drawn uniformly at random
-* If ''len(sk) > 0'':
+* If the optional argument ''sk'' is present:
 ** Let ''rand'' be the byte-wise xor of ''sk'' and ''hash<sub>MuSig/aux</sub>(rand')''<ref>The random data is hashed (with a unique tag) as a precaution against situations where the randomness may be correlated with the secret signing key itself. It is xored with the secret key (rather than combined with it in a hash) to reduce the number of operations exposed to the actual secret key.</ref>.
 * Else: let ''rand = rand' ''
+* If the optional argument ''aggpk'' is not present:
+** Let ''aggpk = empty_bytestring''
+* If the optional argument ''m'' is not present:
+** Let ''m = empty_bytestring''
+* If the optional argument ''extra_in'' is not present:
+** Let ''extra_in = empty_bytestring''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || bytes(8, len(m)) || m || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -327,10 +327,12 @@ Input:
 * If the optional argument ''aggpk'' is not present:
 ** Let ''aggpk = empty_bytestring''
 * If the optional argument ''m'' is not present:
-** Let ''m = empty_bytestring''
+** Let ''m_prefixed = bytes(1, 0)''
+* Else:
+** Let ''m_prefixed = bytes(1, 1) || bytes(8, len(m)) || m''
 * If the optional argument ''extra_in'' is not present:
 ** Let ''extra_in = empty_bytestring''
-* Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || bytes(8, len(m)) || m || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
+* Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''
 * Let ''pubnonce = cbytes(R<sup>*</sup><sub>1</sub>) || cbytes(R<sup>*</sup><sub>2</sub>)''
@@ -605,6 +607,7 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
+* '''0.7.0''' (2022-07-31): Change ''NonceGen'' such that output when message is not present is different from when message is present but has length 0.
 * '''0.6.0''' (2022-07-31): Allow variable length messages, change order of arguments and serialization of the message in the ''NonceGen'' hash function, and add test vectors
 * '''0.5.2''' (2022-06-26): Fix ''aggpk'' in ''NonceGen'' test vectors.
 * '''0.5.1''' (2022-06-22): Rename "ordinary" tweaking to "plain" tweaking.

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -315,7 +315,7 @@ Input:
 Input:
 * The secret signing key ''sk'': a 32-byte array or 0-byte array (optional argument)
 * The aggregate public key ''aggpk'': a 32-byte array or 0-byte array (optional argument)
-* The message ''m'': a 32-byte array or 0-byte array (optional argument)
+* The message ''m'': a byte array (optional argument)<ref name="mlen">In theory, the allowed message size is restricted because SHA256 accepts byte strings only up to size of 2^61-1 bytes (and because of the 8-byte length encoding).</ref>
 * The auxiliary input ''extra_in'': a byte array with ''0 &le; len(extra_in) &le; 2<sup>32</sup>-1'' (optional argument)
 
 '''''NonceGen(sk, aggpk, m, extra_in)''''':
@@ -323,7 +323,7 @@ Input:
 * If ''len(sk) > 0'':
 ** Let ''rand'' be the byte-wise xor of ''sk'' and ''hash<sub>MuSig/aux</sub>(rand')''<ref>The random data is hashed (with a unique tag) as a precaution against situations where the randomness may be correlated with the secret signing key itself. It is xored with the secret key (rather than combined with it in a hash) to reduce the number of operations exposed to the actual secret key.</ref>.
 * Else: let ''rand = rand' ''
-* Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || bytes(1, len(m)) || m || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
+* Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || bytes(8, len(m)) || m || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''
 * Let ''pubnonce = cbytes(R<sup>*</sup><sub>1</sub>) || cbytes(R<sup>*</sup><sub>2</sub>)''
@@ -352,7 +352,7 @@ The Session Context is a data structure consisting of the following elements:
 * The number ''v'' of tweaks with ''0 &le; v < 2^32''
 * The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 * The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
-* The message ''m'': a 32-byte array
+* The message ''m'': a byte array<ref name="mlen" />
 
 We write "Let ''(aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m) = session_ctx''" to assign names to the elements of a Session Context.
 
@@ -411,7 +411,7 @@ Input:
 * The number ''v'' of tweaks with ''0 &le; v < 2^32''
 * The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 * The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
-* The message ''m'': a 32-byte array
+* The message ''m'': a byte array<ref name="mlen" />
 * The index of the signer ''i'' in the public nonces and public keys with ''0 < i &le; u''
 
 '''''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m, i)''''':
@@ -598,6 +598,7 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
+* '''0.6.0''' (2022-07-31): Allow variable length messages, change order of arguments and serialization of the message in the ''NonceGen'' hash function, and add test vectors
 * '''0.5.2''' (2022-06-26): Fix ''aggpk'' in ''NonceGen'' test vectors.
 * '''0.5.1''' (2022-06-22): Rename "ordinary" tweaking to "plain" tweaking.
 * '''0.5.0''' (2022-06-21): Separate ApplyTweak from KeyAgg and introduce KeyGen Context.

--- a/bip-musig2/reference.py
+++ b/bip-musig2/reference.py
@@ -227,7 +227,7 @@ def nonce_hash(rand: bytes, aggpk: bytes, i: int, msg: bytes, extra_in: bytes) -
     buf += rand
     buf += len(aggpk).to_bytes(1, 'big')
     buf += aggpk
-    buf += len(msg).to_bytes(1, 'big')
+    buf += len(msg).to_bytes(8, 'big')
     buf += msg
     buf += len(extra_in).to_bytes(4, 'big')
     buf += extra_in
@@ -257,8 +257,6 @@ def nonce_gen(sk: bytes, aggpk: bytes, msg: bytes, extra_in: bytes) -> Tuple[byt
         raise ValueError('The optional byte array sk must have length 0 or 32.')
     if len(aggpk) not in (0, 32):
         raise ValueError('The optional byte array aggpk must have length 0 or 32.')
-    if len(msg) not in (0, 32):
-        raise ValueError('The optional byte array msg must have length 0 or 32.')
     rand_ = secrets.token_bytes(32)
     return nonce_gen_internal(rand_, sk, aggpk, msg, extra_in)
 
@@ -445,12 +443,12 @@ def test_nonce_gen_vectors():
     extra_in = fill(8)
 
     expected = fromhex_all([
-        'E8F2E103D86800F19A4E97338D371CB885DB2F19D08C0BD205BBA9B906C971D0' +
-        'D786A17718AAFAD6DE025DDDD99DC823E2DFC1AE1DDFE920888AD53FFF423FC4',
-        '8A633F5EECBDB690A6BE4921426F41BE78D509DC1CE894C1215844C0E4C6DE7A' +
-        'BC9A5BE0A3BF3FE312CCB7E4817D2CB17A7CEA8382B73A99A583E323387B3C32',
-        '7B3B5A002356471AF0E961DE2549C121BD0D48ABCEEDC6E034BDDF86AD3E0A18' +
-        '7ECEE674CEF7364B0BC4BEEFB8B66CAD89F98DE2F8C5A5EAD5D1D1E4BD7D04CD'
+        'FDC302CBD26318FF85DE9BB499BCFEB5C54B681A5A2BF1660A3D50A6A97BBCF8' +
+        '040577B50C260D6722894B3B6848B68CC74591D7F3BB2F646F69E2609C494DE6',
+        'CE2AA822EBBC200ED36829E0DBF5C08CC955DEE9C3CF651DA6D37648A6C5417D' +
+        '822BA95D66B455D697BDE2996E4229340A3E60E654E7205994AD4482E3769810',
+        '1E5F9CC2BA2716FFD10E72B21043C5C454A7AE956BFB062C8401158DD3F74059' +
+        '1AC30C8C020B4BAB07768FAE5FF8EEE20C28EC098B790CD367E8C149BF295860'
     ])
 
     # Vector 1
@@ -538,6 +536,7 @@ def test_sign_verify_vectors():
         '2DF67BFFF18E3DE797E13C6475C963048138DAEC5CB20A357CECA7C8424295EA',
         '0D5B651E6DE34A29A12DE7A8B4183B4AE6A7F7FBE15CDCAFA4A3D1BCAABC7517',
         '8D5E0407FB4756EEBCD86264C32D792EE36EEB69E952BBB30B8E41BEBC4D22FA',
+        '0167931A502D28A128DDAC1DC2A53296F00DA663CCDDC9673D79020091A3A58A',
     ])
 
     pk = bytes_from_point(point_mul(G, int_from_bytes(sk)))
@@ -563,14 +562,19 @@ def test_sign_verify_vectors():
     session_ctx = SessionContext(inf_aggnonce, [pk, X[0]], [], [], msg)
     assert sign(secnonce, sk, session_ctx) == expected[3]
 
-    # Vector 5: Signer 2 provided an invalid public key
+    # Vector 5: Empty message
+    empty_msg = b''
+    session_ctx = SessionContext(aggnonce, [pk, X[0], X[1]], [], [], empty_msg)
+    assert sign(secnonce, sk, session_ctx) == expected[4]
+
+    # Vector 6: Signer 2 provided an invalid public key
     invalid_pk = bytes.fromhex('0000000000000000000000000000000000000000000000000000000000000007')
     session_ctx = SessionContext(aggnonce, [X[0], pk, invalid_pk], [], [], msg)
     assertRaises(InvalidContributionError,
                  lambda: sign(secnonce, sk, session_ctx),
                  lambda e: e.signer == 2 and e.contrib == "pubkey")
 
-    # Vector 6: Aggregate nonce is invalid due wrong tag, 0x04, in the first
+    # Vector 7: Aggregate nonce is invalid due wrong tag, 0x04, in the first
     # half
     invalid_aggnonce = bytes.fromhex(
         '048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61' +
@@ -579,7 +583,7 @@ def test_sign_verify_vectors():
     assertRaises(InvalidContributionError,
                  lambda: sign(secnonce, sk, session_ctx),
                  lambda e: e.signer == None and e.contrib == "aggnonce")
-    # Vector 7: Aggregate nonce is invalid because the second half does not
+    # Vector 8: Aggregate nonce is invalid because the second half does not
     # correspond to an X coordinate
     invalid_aggnonce = bytes.fromhex(
         '028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61' +
@@ -588,7 +592,7 @@ def test_sign_verify_vectors():
     assertRaises(InvalidContributionError,
                  lambda: sign(secnonce, sk, session_ctx),
                  lambda e: e.signer == None and e.contrib == "aggnonce")
-    # Vector 8: Aggregate nonce is invalid because second half exceeds field
+    # Vector 9: Aggregate nonce is invalid because second half exceeds field
     # size
     invalid_aggnonce = bytes.fromhex(
         '028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61' +
@@ -599,31 +603,34 @@ def test_sign_verify_vectors():
                  lambda e: e.signer == None and e.contrib == "aggnonce")
 
     # Verification test vectors
-    # Vector 9
-    assert partial_sig_verify(expected[0], [pnonce[0], pnonce[1], pnonce[2]], [pk, X[0], X[1]], [], [], msg, 0)
     # Vector 10
-    assert partial_sig_verify(expected[1], [pnonce[1], pnonce[0], pnonce[2]], [X[0], pk, X[1]], [], [], msg, 1)
+    assert partial_sig_verify(expected[0], [pnonce[0], pnonce[1], pnonce[2]], [pk, X[0], X[1]], [], [], msg, 0)
     # Vector 11
+    assert partial_sig_verify(expected[1], [pnonce[1], pnonce[0], pnonce[2]], [X[0], pk, X[1]], [], [], msg, 1)
+    # Vector 12
     assert partial_sig_verify(expected[2], [pnonce[1], pnonce[2], pnonce[0]], [X[0], X[1], pk], [], [], msg, 2)
 
-    # Vector 12: Both halves of aggregate nonce correspond to point at infinity
+    # Vector 13: Both halves of aggregate nonce correspond to point at infinity
     assert(inf_aggnonce == nonce_agg([pnonce[0], pnonce[3]]))
     assert partial_sig_verify(expected[3], [pnonce[0], pnonce[3]], [pk, X[0]], [], [], msg, 0)
 
-    # Vector 13: Wrong signature (which is equal to the negation of valid signature expected[0])
+    # Vector 14: Empty message
+    assert partial_sig_verify(expected[4], [pnonce[0], pnonce[1], pnonce[2]], [pk, X[0], X[1]], [], [], empty_msg, 0)
+
+    # Vector 15: Wrong signature (which is equal to the negation of valid signature expected[0])
     wrong_sig = bytes.fromhex('97AC833ADCB1AFA42EBF9E0725616F3C9A0D5B614F6FE283CEAAA37A8FFAF406')
     assert not partial_sig_verify(wrong_sig, pnonce, [pk, X[0], X[1]], [], [], msg, 0)
-    # Vector 14: Wrong signer
+    # Vector 16: Wrong signer
     assert not partial_sig_verify(expected[0], pnonce, [pk, X[0], X[1]], [], [], msg, 1)
-    # Vector 15: Signature exceeds group size
+    # Vector 17: Signature exceeds group size
     wrong_sig = bytes.fromhex('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')
     assert not partial_sig_verify(wrong_sig, pnonce, [pk, X[0], X[1]], [], [], msg, 0)
-    # Vector 16: Invalid pubnonce
+    # Vector 18: Invalid pubnonce
     invalid_pubnonce = bytes.fromhex('020000000000000000000000000000000000000000000000000000000000000009')
     assertRaises(InvalidContributionError,
                  lambda: partial_sig_verify(expected[0], [invalid_pubnonce, pnonce[1], pnonce[2]], [pk, X[0], X[1]], [], [], msg, 0),
                  lambda e: e.signer == 0 and e.contrib == "pubnonce")
-    # Vector 17: Invalid public key
+    # Vector 19: Invalid public key
     assertRaises(InvalidContributionError,
                  lambda: partial_sig_verify(expected[0], pnonce, [invalid_pk, X[0], X[1]], [], [], msg, 0),
                  lambda e: e.signer == 0 and e.contrib == "pubkey")


### PR DESCRIPTION
~Draft because~
- ~we should add a test vector for partial sig verification once #9 is merged~
- ~perhaps add a sentence to "Signing Flow" section clarifying that you need to sign 32 byte messages for default BIP-340 verification (not sure right now how variable-length messages will impact existing BIP-340 verification)~