### PR TITLE
Move superscript asterisks to subscript

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -434,7 +434,7 @@ Input:
 * Let ''(Q, gacc, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
 * Let ''R<sub>1,⁎</sub> = cpoint(pubnonce[0:33]), R<sub>2,⁎</sub> = cpoint(pubnonce[33:66])''
-* Let ''R<sub>⁎</sub>' = R<sub>1,∗</sub> + b⋅R<sub>2,⁎</sub>''
+* Let ''R<sub>⁎</sub>' = R<sub>1,⁎</sub> + b⋅R<sub>2,⁎</sub>''
 * Let ''R<sub>⁎</sub> = R<sub>⁎</sub>' '' if ''has_even_y(R)'', otherwise let ''R<sub>⁎</sub> = -R<sub>⁎</sub>' ''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
 * Let ''g' = g⋅gacc mod n''
@@ -557,14 +557,14 @@ when producing a partial signature to ensure that the aggregate signature will c
 
 <poem>
 The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed to check
-  ''s⋅G = R<sup>*</sup> + e⋅a⋅d⋅G''.
+  ''s⋅G = R<sub>⁎</sub> + e⋅a⋅d⋅G''.
 </poem>
 
 <poem>
-The verifier doesn't have access to ''d⋅G'', but can construct it using the xonly public key ''pk<sup>*</sup>'' as follows:
+The verifier doesn't have access to ''d⋅G'', but can construct it using the xonly public key ''pk'' as follows:
 ''d⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d'⋅G
-    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅point(pk<sup>*</sup>)''
+    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅point(pk)''
 Note that the aggregate public key and list of tweaks are inputs to partial signature verification, so the verifier can also construct ''g<sub>v</sub>'' and ''gacc<sub>v</sub>''.
 </poem>
 

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -335,8 +335,8 @@ Input:
 ** Let ''extra_in = empty_bytestring''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
-* Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''
-* Let ''pubnonce = cbytes(R<sup>*</sup><sub>1</sub>) || cbytes(R<sup>*</sup><sub>2</sub>)''
+* Let ''R<sub>1,*</sub> = k<sub>1</sub>⋅G, R<sup>2,*</sub> = k<sub>2</sub>⋅G''
+* Let ''pubnonce = cbytes(R<sub>1,*</sub>) || cbytes(R<sub>2,*</sub>)''
 * Let ''secnonce = bytes(32, k<sub>1</sub>) || bytes(32, k<sub>2</sub>)''
 * Return ''secnonce'' and ''pubnonce''
 
@@ -430,17 +430,17 @@ Input:
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
 * Return success iff no failure occurred before reaching this point.
 
-'''''PartialSigVerifyInternal(psig, pubnonce, pk<sup>*</sup>, session_ctx)''''':
+'''''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)''''':
 * Let ''(Q, gacc, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
-* Let ''R<sup>*</sup><sub>1</sub> = cpoint(pubnonce[0:33]), R<sup>*</sup><sub>2</sub> = cpoint(pubnonce[33:66])''
-* Let ''R<sup>*</sup>' = R<sup>*</sup><sub>1</sub> + b⋅R<sup>*</sup><sub>2</sub>''
-* Let ''R<sup>*</sup> = R<sup>*</sup>' '' if ''has_even_y(R)'', otherwise let ''R<sup>*</sup> = -R<sup>*</sup>' ''
+* Let ''R<sub>1,*</sub> = cpoint(pubnonce[0:33]), R<sub>2,*</sub> = cpoint(pubnonce[33:66])''
+* Let ''R<sub>*</sub>' = R<sub>1,*</sub> + b⋅R<sub>2,*</sub>''
+* Let ''R<sub>*</sub> = R<sub>*</sub>' '' if ''has_even_y(R)'', otherwise let ''R<sub>*</sub> = -R<sub>*</sub>' ''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
 * Let ''g' = g⋅gacc mod n''
-* <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk<sup>*</sup>)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
+* <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅a⋅P''
+* Fail if ''s⋅G &ne; R<sub>*</sub> + e⋅a⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -335,8 +335,8 @@ Input:
 ** Let ''extra_in = empty_bytestring''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
-* Let ''R<sub>1,*</sub> = k<sub>1</sub>⋅G, R<sup>2,*</sub> = k<sub>2</sub>⋅G''
-* Let ''pubnonce = cbytes(R<sub>1,*</sub>) || cbytes(R<sub>2,*</sub>)''
+* Let ''R<sub>1,⁎</sub> = k<sub>1</sub>⋅G, R<sub>2,⁎</sub> = k<sub>2</sub>⋅G''
+* Let ''pubnonce = cbytes(R<sub>1,⁎</sub>) || cbytes(R<sub>2,⁎</sub>)''
 * Let ''secnonce = bytes(32, k<sub>1</sub>) || bytes(32, k<sub>2</sub>)''
 * Return ''secnonce'' and ''pubnonce''
 
@@ -433,14 +433,14 @@ Input:
 '''''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)''''':
 * Let ''(Q, gacc, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
-* Let ''R<sub>1,*</sub> = cpoint(pubnonce[0:33]), R<sub>2,*</sub> = cpoint(pubnonce[33:66])''
-* Let ''R<sub>*</sub>' = R<sub>1,*</sub> + b⋅R<sub>2,*</sub>''
-* Let ''R<sub>*</sub> = R<sub>*</sub>' '' if ''has_even_y(R)'', otherwise let ''R<sub>*</sub> = -R<sub>*</sub>' ''
+* Let ''R<sub>1,⁎</sub> = cpoint(pubnonce[0:33]), R<sub>2,⁎</sub> = cpoint(pubnonce[33:66])''
+* Let ''R<sub>⁎</sub>' = R<sub>1,∗</sub> + b⋅R<sub>2,⁎</sub>''
+* Let ''R<sub>⁎</sub> = R<sub>⁎</sub>' '' if ''has_even_y(R)'', otherwise let ''R<sub>⁎</sub> = -R<sub>⁎</sub>' ''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
 * Let ''g' = g⋅gacc mod n''
 * <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Fail if ''s⋅G &ne; R<sub>*</sub> + e⋅a⋅P''
+* Fail if ''s⋅G &ne; R<sub>⁎</sub> + e⋅a⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -431,16 +431,16 @@ Input:
 * Return success iff no failure occurred before reaching this point.
 
 '''''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)''''':
-* Let ''(Q, gacc, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
+* Let ''(Q, gacc, _, b, fullR, e) = GetSessionValues(session_ctx)''; fail if that fails
 * Let ''s = int(psig)''; fail if ''s &ge; n''
 * Let ''R<sub>1,⁎</sub> = cpoint(pubnonce[0:33]), R<sub>2,⁎</sub> = cpoint(pubnonce[33:66])''
-* Let ''R<sub>⁎</sub>' = R<sub>1,⁎</sub> + b⋅R<sub>2,⁎</sub>''
-* Let ''R<sub>⁎</sub> = R<sub>⁎</sub>' '' if ''has_even_y(R)'', otherwise let ''R<sub>⁎</sub> = -R<sub>⁎</sub>' ''
+* Let ''R' = R<sub>1,⁎</sub> + b⋅R<sub>2,⁎</sub>''
+* Let ''R = R' '' if ''has_even_y(fullR)'', otherwise let ''R = -R' ''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
 * Let ''g' = g⋅gacc mod n''
 * <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Fail if ''s⋅G &ne; R<sub>⁎</sub> + e⋅a⋅P''
+* Fail if ''s⋅G &ne; R + e⋅a⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====
@@ -556,8 +556,8 @@ when producing a partial signature to ensure that the aggregate signature will c
 </poem>
 
 <poem>
-The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed to check
-  ''s⋅G = R<sub>⁎</sub> + e⋅a⋅d⋅G''.
+Given a partial signature ''(R, s)'', the ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed to check
+  ''s⋅G = R + e⋅a⋅d⋅G''.
 </poem>
 
 <poem>

--- a/bip-musig2/reference.py
+++ b/bip-musig2/reference.py
@@ -354,7 +354,7 @@ def partial_sig_verify(psig: bytes, pubnonces: List[bytes], pubkeys: List[bytes]
     session_ctx = SessionContext(aggnonce, pubkeys, tweaks, is_xonly, msg)
     return partial_sig_verify_internal(psig, pubnonces[i], pubkeys[i], session_ctx)
 
-def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk_: bytes, session_ctx: SessionContext) -> bool:
+def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk: bytes, session_ctx: SessionContext) -> bool:
     (Q, gacc, _, b, R, e) = get_session_values(session_ctx)
     s = int_from_bytes(psig)
     if s >= n:
@@ -365,7 +365,7 @@ def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk_: bytes, sessio
     R_ = R__ if has_even_y(R) else point_negate(R__)
     g = 1 if has_even_y(Q) else n - 1
     g_ = g * gacc % n
-    P = point_mul(lift_x(pk_), g_)
+    P = point_mul(lift_x(pk), g_)
     if P is None:
         return False
     a = get_session_key_agg_coeff(session_ctx, P)


### PR DESCRIPTION
Except for pk, where we just drop them because there's no risk of confusing pk
with aggpk.

Fixes #18.