### PR TITLE
Remove all superscript asterisks

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -335,8 +335,8 @@ Input:
 ** Let ''extra_in = empty_bytestring''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/nonce</sub>(rand || bytes(1, len(aggpk)) || aggpk || m_prefixed || bytes(4, len(extra_in)) || extra_in || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
-* Let ''R<sup>*</sup><sub>1</sub> = k<sub>1</sub>⋅G, R<sup>*</sup><sub>2</sub> = k<sub>2</sub>⋅G''
-* Let ''pubnonce = cbytes(R<sup>*</sup><sub>1</sub>) || cbytes(R<sup>*</sup><sub>2</sub>)''
+* Let ''R<sub>1</sub> = k<sub>1</sub>⋅G, R<sub>2</sub> = k<sub>2</sub>⋅G''
+* Let ''pubnonce = cbytes(R<sub>1</sub>) || cbytes(R<sub>2</sub>)''
 * Let ''secnonce = bytes(32, k<sub>1</sub>) || bytes(32, k<sub>2</sub>)''
 * Return ''secnonce'' and ''pubnonce''
 
@@ -430,17 +430,17 @@ Input:
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
 * Return success iff no failure occurred before reaching this point.
 
-'''''PartialSigVerifyInternal(psig, pubnonce, pk<sup>*</sup>, session_ctx)''''':
+'''''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)''''':
 * Let ''(Q, gacc, _, b, R, e) = GetSessionValues(session_ctx)''; fail if that fails
-* Let ''s = int(psig)''; fail if ''s &ge; n''
-* Let ''R<sup>*</sup><sub>1</sub> = cpoint(pubnonce[0:33]), R<sup>*</sup><sub>2</sub> = cpoint(pubnonce[33:66])''
-* Let ''R<sup>*</sup>' = R<sup>*</sup><sub>1</sub> + b⋅R<sup>*</sup><sub>2</sub>''
-* Let ''R<sup>*</sup> = R<sup>*</sup>' '' if ''has_even_y(R)'', otherwise let ''R<sup>*</sup> = -R<sup>*</sup>' ''
+* Let ''sp = int(psig)''; fail if ''s &ge; n''
+* Let ''Rp<sub>1</sub> = cpoint(pubnonce[0:33]), Rp<sub>2</sub> = cpoint(pubnonce[33:66])''
+* Let ''Rp' = Rp<sub>1</sub> + b⋅Rp<sub>2</sub>''
+* Let ''Rp = Rp' '' if ''has_even_y(R)'', otherwise let ''Rp = -Rp' ''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
 * Let ''g' = g⋅gacc mod n''
-* <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk<sup>*</sup>)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
+* <div id="SigVerify negation"></div>Let ''P = g'⋅point(pk)''; fail if that fails (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Fail if ''s⋅G &ne; R<sup>*</sup> + e⋅a⋅P''
+* Fail if ''sp⋅G &ne; Rp + e⋅a⋅P''
 * Return success iff no failure occurred before reaching this point.
 
 ==== Partial Signature Aggregation ====

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -402,9 +402,9 @@ Input:
 * Fail if ''d' = 0'' or ''d' &ge; n''
 * Let ''P = d'⋅G''
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''; fail if that fails
-* Let ''gp = 1'' if ''has_even_y(P)'', otherwise let ''gp = -1 mod n''
+* Let ''gpk = 1'' if ''has_even_y(P)'', otherwise let ''gpk = -1 mod n''
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
-* <div id="Sign negation"></div>Let ''d = g⋅gacc⋅gp⋅d' mod n'' (See [[negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]])
+* <div id="Sign negation"></div>Let ''d = g⋅gacc⋅gpk⋅d' mod n'' (See [[negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]])
 * Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅a⋅d) mod n''
 * Let ''psig = bytes(32, s)''
 * Let ''pubnonce = cbytes(k'<sub>1</sub>⋅G) || cbytes(k'<sub>2</sub>⋅G)''
@@ -502,8 +502,8 @@ The following elliptic curve points arise as intermediate steps in the MuSig2 pr
 The signer's goal is to produce a partial signature corresponding to the final result of key aggregation and tweaking, i.e. the X-only public key ''with_even_y(Q<sub>v</sub>)''.
 
 <poem>
-We define ''gp<sub>i</sub>'' for ''1 &le; i &le; u'' to be ''gp '' as computed in the ''Sign'' algorithm of the ''i''-th signer. Note that ''gp<sub>i</sub>'' indicates whether the ''i''-th signer needed to negate their secret key to produce an X-only public key. In particular,
-    ''P<sub>i</sub> = gp<sub>i</sub>⋅d'<sub>i</sub>⋅G''.
+We define ''gpk<sub>i</sub>'' for ''1 &le; i &le; u'' to be ''gpk '' as computed in the ''Sign'' algorithm of the ''i''-th signer. Note that ''gpk<sub>i</sub>'' indicates whether the ''i''-th signer needed to negate their secret key to produce an X-only public key. In particular,
+    ''P<sub>i</sub> = gpk<sub>i</sub>⋅d'<sub>i</sub>⋅G''.
 
 For ''1 &le; i &le; v'', we denote the value ''g'' computed in the ''i''-th execution of ''ApplyTweak'' by ''g<sub>i-1</sub>''. Therefore, ''g<sub>i-1</sub>'' is ''-1 mod n'' if and only if ''is_xonly_t<sub>i</sub>'' is true and ''Q<sub>i-1</sub>'' has an odd Y coordinate. In other words, ''g<sub>i-1</sub>'' indicates whether ''Q<sub>i-1</sub>'' needed to be negated to apply an X-only tweak:
     ''f(i-1) = g<sub>i-1</sub>⋅Q<sub>i-1</sub>'' for ''1 &le; i &le; v''.
@@ -541,17 +541,17 @@ Then we have
     ''with_even_y(Q<sub>v</sub>) - g<sub>v</sub>⋅tacc<sub>v</sub>⋅G
         = g<sub>v</sub>⋅gacc<sub>v</sub>⋅Q<sub>0</sub>
         = g<sub>v</sub>⋅gacc<sub>v</sub>⋅(a<sub>1</sub>⋅P<sub>1</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>)
-        = g<sub>v</sub>⋅gacc<sub>v</sub>⋅(a<sub>1</sub>⋅gp<sub>1</sub>⋅d'<sub>1</sub>⋅G + ... + a<sub>u</sub>⋅gp<sub>u</sub>⋅d'<sub>u</sub>⋅G)
-        = sum<sub>i=1..u</sub>(g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp<sub>i</sub>⋅a<sub>i</sub>⋅d'<sub>i</sub>)*G''.
+        = g<sub>v</sub>⋅gacc<sub>v</sub>⋅(a<sub>1</sub>⋅gpk<sub>1</sub>⋅d'<sub>1</sub>⋅G + ... + a<sub>u</sub>⋅gpk<sub>u</sub>⋅d'<sub>u</sub>⋅G)
+        = sum<sub>i=1..u</sub>(g<sub>v</sub>⋅gacc<sub>v</sub>⋅gpk<sub>i</sub>⋅a<sub>i</sub>⋅d'<sub>i</sub>)*G''.
 </poem>
 
-Intuitively, ''gacc<sub>i</sub>'' tracks accumulated sign flipping and ''tacc<sub>i</sub>'' tracks the accumulated tweak value after applying the first ''i'' individual tweaks. Additionally, ''g<sub>v</sub>'' indicates whether ''Q<sub>v</sub>'' needed to be negated to produce the final X-only result, and ''gp<sub>i</sub>'' indicates whether ''d'<sub>i</sub>'' needs to be negated to produce the initial X-only key ''P<sub>i</sub>''. Thus, signer ''i'' multiplies its secret key ''d'<sub>i</sub>'' with ''g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp<sub>i</sub>'' in the ''[[#Sign negation|Sign]]'' algorithm.
+Intuitively, ''gacc<sub>i</sub>'' tracks accumulated sign flipping and ''tacc<sub>i</sub>'' tracks the accumulated tweak value after applying the first ''i'' individual tweaks. Additionally, ''g<sub>v</sub>'' indicates whether ''Q<sub>v</sub>'' needed to be negated to produce the final X-only result, and ''gpk<sub>i</sub>'' indicates whether ''d'<sub>i</sub>'' needs to be negated to produce the initial X-only key ''P<sub>i</sub>''. Thus, signer ''i'' multiplies its secret key ''d'<sub>i</sub>'' with ''g<sub>v</sub>⋅gacc<sub>v</sub>⋅gpk<sub>i</sub>'' in the ''[[#Sign negation|Sign]]'' algorithm.
 
 ==== Negation Of The Public Key When Partially Verifying ====
 
 <poem>
 As explained in [[#negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]] the signer uses a possibly negated secret key
-    ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d' mod n''
+    ''d = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gpk⋅d' mod n''
 when producing a partial signature to ensure that the aggregate signature will correspond to an aggregate public key with even Y coordinate.
 </poem>
 
@@ -563,7 +563,7 @@ The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed t
 <poem>
 The verifier doesn't have access to ''d⋅G'', but can construct it using the xonly public key ''pk<sup>*</sup>'' as follows:
 ''d⋅G
-    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gp⋅d'⋅G
+    = g<sub>v</sub>⋅gacc<sub>v</sub>⋅gpk⋅d'⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅point(pk<sup>*</sup>)''
 Note that the aggregate public key and list of tweaks are inputs to partial signature verification, so the verifier can also construct ''g<sub>v</sub>'' and ''gacc<sub>v</sub>''.
 </poem>

--- a/bip-musig2/reference.py
+++ b/bip-musig2/reference.py
@@ -334,13 +334,13 @@ def sign(secnonce: bytes, sk: bytes, session_ctx: SessionContext) -> bytes:
     gp = 1 if has_even_y(P) else n - 1
     g = 1 if has_even_y(Q) else n - 1
     d = g * gacc * gp * d_ % n
-    s = (k_1 + b * k_2 + e * a * d) % n
-    psig = bytes_from_int(s)
-    R_1_ = point_mul(G, k_1_)
-    R_2_ = point_mul(G, k_2_)
-    assert R_1_ is not None
-    assert R_2_ is not None
-    pubnonce = cbytes(R_1_) + cbytes(R_2_)
+    sp = (k_1 + b * k_2 + e * a * d) % n
+    psig = bytes_from_int(sp)
+    Rp_1 = point_mul(G, k_1_)
+    Rp_2 = point_mul(G, k_2_)
+    assert Rp_1 is not None
+    assert Rp_2 is not None
+    pubnonce = cbytes(Rp_1) + cbytes(Rp_2)
     # Optional correctness check. The result of signing should pass signature verification.
     assert partial_sig_verify_internal(psig, pubnonce, bytes_from_point(P), session_ctx)
     return psig
@@ -354,22 +354,22 @@ def partial_sig_verify(psig: bytes, pubnonces: List[bytes], pubkeys: List[bytes]
     session_ctx = SessionContext(aggnonce, pubkeys, tweaks, is_xonly, msg)
     return partial_sig_verify_internal(psig, pubnonces[i], pubkeys[i], session_ctx)
 
-def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk_: bytes, session_ctx: SessionContext) -> bool:
+def partial_sig_verify_internal(psig: bytes, pubnonce: bytes, pk: bytes, session_ctx: SessionContext) -> bool:
     (Q, gacc, _, b, R, e) = get_session_values(session_ctx)
-    s = int_from_bytes(psig)
-    if s >= n:
+    sp = int_from_bytes(psig)
+    if sp >= n:
         return False
-    R_1_ = cpoint(pubnonce[0:33])
-    R_2_ = cpoint(pubnonce[33:66])
-    R__ = point_add(R_1_, point_mul(R_2_, b))
-    R_ = R__ if has_even_y(R) else point_negate(R__)
+    Rp_1 = cpoint(pubnonce[0:33])
+    Rp_2 = cpoint(pubnonce[33:66])
+    Rp_ = point_add(Rp_1, point_mul(Rp_2, b))
+    Rp = Rp_ if has_even_y(R) else point_negate(Rp_)
     g = 1 if has_even_y(Q) else n - 1
     g_ = g * gacc % n
-    P = point_mul(lift_x(pk_), g_)
+    P = point_mul(lift_x(pk), g_)
     if P is None:
         return False
     a = get_session_key_agg_coeff(session_ctx, P)
-    return point_mul(G, s) == point_add(R_, point_mul(P, e * a % n))
+    return point_mul(G, sp) == point_add(Rp, point_mul(P, e * a % n))
 
 def partial_sig_agg(psigs: List[bytes], session_ctx: SessionContext) -> bytes:
     (Q, _, tacc, _, R, e) = get_session_values(session_ctx)


### PR DESCRIPTION
I believe their purpose to stress that the variable belongs to a single signer.
But they're not necessary to indicate that  `pk` refers to an individual public
key because we use `aggpk` for the aggregate public key.
In case of `R`, this commit replaces the asterisks by `Rp` (for _p_artial).

Fixes #18.


Alternative to #46 . When I had this fully ready, I realized that #47 may be much simpler, so we have a choice now.