### PR TITLE
Drop misleading sentence

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -58,7 +58,6 @@ The MuSig2 variant in this specification stands out by combining all of the foll
 This specification is written with a focus on clarity.
 As a result, the specified algorithms are not always optimal in terms of computation and space.
 In particular, some values are recomputed but can be cached in actual implementations (see [[#signing-flow|Signing Flow]]).
-Also, the signers' public nonces are serialized in compressed format (33 bytes) instead of the smaller (32 bytes) but more complicated X-only serialization.
 
 == Description ==
 


### PR DESCRIPTION
This sounded like it was an "style/implementation" detail of how the spec is written but it's actually observable behavior. We could add a real rationale for this design to Design (maybe including the discussion about associativity of NonceGen) but I don't think it's necessary.