### PR TITLE
test vectors: fix "38-byte message" sign_verify vector

### DIFF
--- a/bip-musig2/sign_verify_vectors.json
+++ b/bip-musig2/sign_verify_vectors.json
@@ -75,7 +75,7 @@
             "aggnonce_index": 0,
             "msg_index": 2,
             "signer_index": 0,
-            "expected": "0203172BB999C6FD7EFA3A1021CA2B2C92AC74C64002748D4CFB0EB7D4BF020D",
+            "expected": "E184351828DA5094A97C79CABDAAA0BFB87608C32E8829A4DF5340A6F243B78C",
             "comment": "38-byte message"
         }
     ],


### PR DESCRIPTION
This happened because this test vector was added while the "Switch from X-only
to plain public key inputs" was in-flight. This PR required regenerating all
valid sign_verify test vectors, but the new vector was simply missed. Running
tests.sh would have caught this.