### PR TITLE
Add explicit PlainPubKey algorithm

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -249,6 +249,17 @@ The following conventions are used, with constants as defined for [https://www.s
 
 === Key Generation ===
 
+==== Key Generation of an Individual Signer ====
+
+<div>
+Algorithm ''IndividualPubkey(sk)''<ref>The ''IndividualPubkey'' algorithm matches the key generation procedure traditionally used for ECDSA in Bitcoin</ref>:
+* Inputs:
+** The secret key ''sk'': a 32-byte array, freshly generated uniformly at random
+* Let ''d' = int(sk)''.
+* Fail if ''d' = 0'' or ''d' &ge; n''.
+* Return ''cbytes(d'⋅G)''.
+</div>
+
 ==== KeyGen Context ====
 
 The KeyGen Context is a data structure consisting of the following elements:
@@ -523,7 +534,7 @@ The reference implementation is for demonstration purposes only and not to be us
 Implementers must avoid modifying the ''NonceGen'' algorithm without being fully aware of the implications.
 
 One potential pitfall emerges when ''NonceGen'' is altered so the signer's public key ''pk'' is not part of the returned ''secnonce'' array.
-This specification makes the signer provide ''pk'' at nonce generation time and write ''pk'' into the ''secnonce'' array (and check ''pk'' against ''sk'' in ''Sign'') to ensure that the public key of the signer is determined before sending out the ''pubnonce''.
+This specification makes the signer provide ''pk'' at nonce generation time and write ''pk'' into the ''secnonce'' array (and check ''pk'' against ''IndividualPubkey(sk)'' in ''Sign'') to ensure that the public key of the signer is determined before sending out the ''pubnonce''.
 If the public key is not determined before sending out the ''pubnonce'', an adversary can forge a signature by influencing the individual tweak of a victim signer after seeing the ''pubnonce'' (see the [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html bitcoin-dev mailing list post] and [https://github.com/jonasnick/musig2-tweaking writeup] for the details).
 Thus, implementations must guarantee that the public key of the signer is determined before sending out the ''pubnonce'' if they cannot rule out that the signer's individual key is tweaked (e.g., derived via BIP32) with a tweak known to the adversary (e.g., as in BIP32 unhardened derivation).<ref>The nonce generation algorithm as given in the [https://eprint.iacr.org/2020/1261 MuSig2 paper] does not take ''pk'' as an input (and does not store it in the ''secnonce''). However, the security model considered in the paper does not cover security for signers who tweak their individual keys.</ref>
 
@@ -729,10 +740,11 @@ An exception to this rule is <code>MAJOR</code> version zero (0.y.z) which is fo
 The <code>MINOR</code> version is incremented whenever the inputs or the output of an algorithm changes in a backward-compatible way or new backward-compatible functionality is added.
 The <code>PATCH</code> version is incremented for other changes that are noteworthy (bug fixes, test vectors, important clarifications, etc.).
 
-* '''1.0.0-rc.3''' (2023-01-11):
+* '''1.0.0-rc.3''' (2023-02-24):
 ** Improve ''NonceGen'' test vectors by not using an all-zero hex string as ''rand_'' values. This change addresses potential issues in some implementations that interpret this as a special value indicating uninitialized memory or a broken random number generator and therefore return an error.
 ** Fix invalid length of a ''pubnonce'' in the ''PartialSigVerify'' test vectors.
 ** Improve ''KeySort'' test vector.
+** Add explicit ''IndividualPubkey'' algorithm.
 * '''1.0.0-rc.2''' (2022-10-28):
 ** Fix vulnerability that can occur in certain unusual scenarios (see [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html bitcoin-dev mailing list]: Add mandatory ''pk'' argument to ''NonceGen'', append ''pk'' to ''secnonce'' and check in ''Sign'' that the ''pk'' in ''secnonce'' matches. Update test vectors.
 ** Make sure that signer's key is in list of input public keys by adding failure case to ''GetSessionKeyAggCoeff'' and add test vectors.

--- a/bip-musig2/reference.py
+++ b/bip-musig2/reference.py
@@ -170,7 +170,7 @@ def cpoint_ext(x: bytes) -> Optional[Point]:
         return cpoint(x)
 
 # Return the plain public key corresponding to a given secret key
-def plain_pk_gen(seckey: bytes) -> PlainPk:
+def individual_pk(seckey: bytes) -> PlainPk:
     d0 = int_from_bytes(seckey)
     if not (1 <= d0 <= n - 1):
         raise ValueError('The secret key must be an integer in the range 1..n-1.')
@@ -412,7 +412,7 @@ def deterministic_sign(sk: bytes, aggothernonce: bytes, pubkeys: List[PlainPk], 
     assert R_s1 is not None
     assert R_s2 is not None
     pubnonce = cbytes(R_s1) + cbytes(R_s2)
-    secnonce = bytearray(bytes_from_int(k_1) + bytes_from_int(k_2) + plain_pk_gen(sk))
+    secnonce = bytearray(bytes_from_int(k_1) + bytes_from_int(k_2) + individual_pk(sk))
     try:
         aggnonce = nonce_agg([pubnonce, aggothernonce])
     except Exception:
@@ -583,7 +583,7 @@ def test_sign_verify_vectors() -> None:
     sk = bytes.fromhex(test_data["sk"])
     X = fromhex_all(test_data["pubkeys"])
     # The public key corresponding to sk is at index 0
-    assert X[0] == plain_pk_gen(sk)
+    assert X[0] == individual_pk(sk)
 
     secnonces = fromhex_all(test_data["secnonces"])
     pnonce = fromhex_all(test_data["pnonces"])
@@ -663,7 +663,7 @@ def test_tweak_vectors() -> None:
     sk = bytes.fromhex(test_data["sk"])
     X = fromhex_all(test_data["pubkeys"])
     # The public key corresponding to sk is at index 0
-    assert X[0] == plain_pk_gen(sk)
+    assert X[0] == individual_pk(sk)
 
     secnonce = bytearray(bytes.fromhex(test_data["secnonce"]))
     pnonce = fromhex_all(test_data["pnonces"])
@@ -720,7 +720,7 @@ def test_det_sign_vectors() -> None:
     sk = bytes.fromhex(test_data["sk"])
     X = fromhex_all(test_data["pubkeys"])
     # The public key corresponding to sk is at index 0
-    assert X[0] == plain_pk_gen(sk)
+    assert X[0] == individual_pk(sk)
 
     msgs = fromhex_all(test_data["msgs"])
 
@@ -813,8 +813,8 @@ def test_sign_and_verify_random(iters: int) -> None:
     for i in range(iters):
         sk_1 = secrets.token_bytes(32)
         sk_2 = secrets.token_bytes(32)
-        pk_1 = plain_pk_gen(sk_1)
-        pk_2 = plain_pk_gen(sk_2)
+        pk_1 = individual_pk(sk_1)
+        pk_2 = individual_pk(sk_2)
         pubkeys = [pk_1, pk_2]
 
         # In this example, the message and aggregate pubkey are known


### PR DESCRIPTION
Fixes #78. I didn't change `Sign` to use `PlainPubKey` because it looks a bit ugly (it's extremely redundant).