### PR TITLE
Rename KeyGen Context to KeyAgg Context

### DIFF
--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -16,7 +16,7 @@
 
 This document proposes a standard for the [https://eprint.iacr.org/2020/1261.pdf MuSig2] multi-signature scheme.
 The standard is compatible with [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340] public keys and signatures.
-It supports ''tweaking'', which allows deriving [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32] child keys from aggregate keys and creating [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] Taproot outputs with key and script paths.
+It supports ''tweaking'', which allows deriving [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32] child keys from aggregate public keys and creating [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] Taproot outputs with key and script paths.
 
 === Copyright ===
 
@@ -24,7 +24,7 @@ This document is licensed under the 3-clause BSD license.
 
 === Motivation ===
 
-MuSig2 is a multi-signature scheme that allows multiple signers to create a single aggregate public key and cooperatively create ordinary Schnorr signatures valid under the aggregate key.
+MuSig2 is a multi-signature scheme that allows multiple signers to create a single aggregate public key and cooperatively create ordinary Schnorr signatures valid under the aggregate public key.
 Signing requires interaction between ''all'' signers involved in key aggregation.
 (MuSig2 is a ''n-of-n'' multi-signature scheme and not a ''t-of-n'' threshold-signature scheme.)
 
@@ -35,7 +35,7 @@ It can be spent using MuSig2 to produce a signature for the key-based spending p
 The on-chain footprint of a MuSig2 Taproot output is essentially a single BIP340 public key, and a transaction spending the output only requires a single signature cooperatively produced by all signers. This is '''more compact''' and has '''lower verification cost''' than each signer providing an individual public key and signature, as would be required by an ''n-of-n'' policy implemented using <code>OP_CHECKSIGADD</code> as introduced in ([https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki BIP342]).
 As a side effect, the number ''n'' of signers is not limited by any consensus rules when using MuSig2.
 
-Moreover, MuSig2 offers a '''higher level of privacy''' than <code>OP_CHECKSIGADD</code>: MuSig2 Taproot outputs are indistinguishable for a blockchain observer from regular, single-signer Taproot outputs even though they are actually controlled by multiple signers. By tweaking an aggregate key, the shared Taproot output can have script spending paths that are hidden unless used.
+Moreover, MuSig2 offers a '''higher level of privacy''' than <code>OP_CHECKSIGADD</code>: MuSig2 Taproot outputs are indistinguishable for a blockchain observer from regular, single-signer Taproot outputs even though they are actually controlled by multiple signers. By tweaking an aggregate public key, the shared Taproot output can have script spending paths that are hidden unless used.
 
 There are multi-signature schemes other than MuSig2 that are fully compatible with Schnorr signatures.
 The MuSig2 variant proposed below stands out by combining all the following features:
@@ -46,7 +46,7 @@ The MuSig2 variant proposed below stands out by combining all the following feat
 
 === Design ===
 
-* '''Compatibility with BIP340''': In this proposal, the aggregate public key is a BIP340 X-only public key, and the signature output at the end of the signing protocol is a BIP340 signature that passes BIP340 verification for the aggregate key and a message. The public keys that are input to the key aggregation algorithm are ''plain'' public keys in compressed format.
+* '''Compatibility with BIP340''': In this proposal, the aggregate public key is a BIP340 X-only public key, and the signature output at the end of the signing protocol is a BIP340 signature that passes BIP340 verification for the aggregate public key and a message. The public keys that are input to the key aggregation algorithm are ''plain'' public keys in compressed format.
 * '''Tweaking for BIP32 derivations and Taproot''': This proposal supports tweaking aggregate public keys and signing for tweaked aggregate public keys. We distinguish two modes of tweaking: ''Plain'' tweaking can be used to derive child aggregate public keys per [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32]. ''X-only'' tweaking, on the other hand, allows creating a [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] tweak to add script paths to a Taproot output. See section [[#tweaking|Tweaking]] below for details.
 * '''Non-interactive signing with preprocessing''': The first communication round, exchanging the nonces, can happen before the message or the exact set of signers is determined. Once the parameters of the signing session are finalized, the signers can send partial signatures without additional interaction.
 * '''Key aggregation optionally independent of order''': The output of the key aggregation algorithm depends on the order of the input public keys. Key aggregation does not sort the public keys by default because applications often already have a canonical order of signers. Nonetheless, applications can mandate sorting before aggregation,<ref>Applications that sort input public keys before aggregation should ensure that the implementation of sorting is reasonably efficient, and in particular does not degenerate to quadratic runtime on pathological inputs.</ref> and this proposal specifies a canonical order to sort the public keys before key aggregation. Sorting will ensure the same output, independent of the initial order.
@@ -107,13 +107,13 @@ Plain public keys are byte strings of length 33 (often called ''compressed'' for
 In contrast, X-only public keys are 32-byte strings defined in [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340].
 
 The individual public keys of signers as input to the key aggregation algorithm ''KeyAgg'' (and to ''GetSessionValues'' and ''PartialSigVerify'') are plain public keys.
-The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate key (see [[#tweaking|below]]),
+The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate public key (see [[#tweaking|below]]),
 and it can be used to produce an X-only aggregate public key, or a plain aggregate public key.
 In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
 To get the plain aggregate public key, which is required for some applications of [[#tweaking|tweaking]], implementations call ''GetPlainPubkey'' instead.
 
-The aggregate key produced by ''KeyAgg'' is dependent on the order of the input public keys.
-If the application does not have a canonical order of the signers, the public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate key is independent of the order of signers.
+The aggregate public key produced by ''KeyAgg'' is dependent on the order of the input public keys.
+If the application does not have a canonical order of the signers, the public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate public key is independent of the order of signers.
 
 The same public key is allowed to occur more than once in the input of ''KeyAgg'' and ''KeySort''.
 This is by design: All algorithms in this proposal handle multiple signers who (claim to) have identical public keys properly,
@@ -188,7 +188,7 @@ In order to apply a tweak, the KeyGen Context output by ''KeyAgg'' is provided t
 The resulting KeyGen Context can be used to apply another tweak with ''ApplyTweak'' or obtain the aggregate public key with ''GetXonlyPubkey'' or ''GetPlainPubkey''.
 
 In addition to public keys, the ''KeyAgg'' algorithm accepts tweaks, which modify the aggregate public key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
-For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
+For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate public key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
 
 The purpose of specifying tweaking is to ensure compatibility with existing uses of tweaking, i.e., that the result of signing is a valid signature for the tweaked public key.
 The MuSig2 algorithms take arbitrary tweaks as input but accepting arbitrary tweaks may negatively affect the security of the scheme.<ref>It is an open question whether allowing arbitrary tweaks from an adversary affects the unforgeability of MuSig2.</ref>

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -170,7 +170,7 @@ Aborts are identifiable for an honest party if the following conditions hold in 
 If these conditions hold and an honest party (signer or aggregator) runs an algorithm that fails due to invalid protocol contributions from malicious signers, then the algorithm run by the honest party will output the index of exactly one malicious signer.
 Additionally, if the honest parties agree on the contributions sent by all signers in the signing session, all the honest parties who run the aborting algorithm will identify the same malicious signer.
 
-==== Further remarks ====
+==== Further Remarks ====
 
 Some of the algorithms specified below may also assign blame to a malicious aggregator.
 While this is possible for some particular misbehavior of the aggregator, it is not guaranteed that a malicious aggregator can be identified.
@@ -178,7 +178,7 @@ More specifically, a malicious aggregator (whose existence violates the second c
 
 The only purpose of the algorithm ''PartialSigVerify'' is to ensure identifiable aborts, and it is not necessary to use it when identifiable aborts are not desired.
 In particular, partial signatures are ''not'' signatures.
-An adversary can forge a partial signature, i.e., create a partial signature without knowing the secret key for the claimed public key.<ref>Assume an adversary wants to forge a partial signature for public key ''P''. It joins the signing session pretending to be two different signers, one with public key ''P'' and one with another public key. The adversary can then set the second signer's nonce such that it will be able to produce a partial signature for ''P'', but not for the other claimed signer. An explanation of the individual steps required to create a partial signature forgery can be found in [https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b a write up by Adam Gibson].</ref>
+An adversary can forge a partial signature, i.e., create a partial signature without knowing the secret key for the claimed public key.<ref>Assume an adversary wants to forge a partial signature for public key ''P''. It joins the signing session pretending to be two different signers, one with public key ''P'' and one with another public key. The adversary can then set the second signer's nonce such that it will be able to produce a partial signature for ''P'' but not for the other claimed signer. An explanation of the individual steps required to create a partial signature forgery can be found in [https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b a write up by Adam Gibson].</ref>
 However, if ''PartialSigVerify'' succeeds for all partial signatures then ''PartialSigAgg'' will return a valid Schnorr signature.<ref>Given a list of public keys, it is an open question whether a valid BIP-340 signature for the aggregate of the public keys is proof of knowledge of the secret keys corresponding to the input list.</ref>
 
 === Tweaking the Aggregate Public Key ===
@@ -190,7 +190,7 @@ The resulting KeyGen Context can be used to apply another tweak with ''ApplyTwea
 In addition to public keys, the ''KeyAgg'' algorithm accepts tweaks, which modify the aggregate public key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
 For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate public key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
 
-The purpose of specifying tweaking is to ensure compatibility with existing uses of tweaking, i.e., that the result of signing is a valid signature for the tweaked public key.
+The purpose of supporting tweaking is to ensure compatibility with existing uses of tweaking, i.e., that the result of signing is a valid signature for the tweaked public key.
 The MuSig2 algorithms take arbitrary tweaks as input but accepting arbitrary tweaks may negatively affect the security of the scheme.<ref>It is an open question whether allowing arbitrary tweaks from an adversary affects the unforgeability of MuSig2.</ref>
 Instead, signers should obtain the tweaks according to other specifications.
 This typically involves deriving the tweaks from a hash of the aggregate public key and some other information.
@@ -465,7 +465,7 @@ Algorithm ''Sign(secnonce, sk, session_ctx)'':
 * Let ''s = (k<sub>1</sub> + b⋅k<sub>2</sub> + e⋅a⋅d) mod n''
 * Let ''psig = bytes(32, s)''
 * Let ''pubnonce = cbytes(k<sub>1</sub>'⋅G) || cbytes(k<sub>2</sub>'⋅G)''
-* If ''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)'' (see below) returns failure, fail<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended, but can be omitted if the computation cost is prohibitive.</ref>
+* If ''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)'' (see below) returns failure, fail<ref>Verifying the signature before leaving the signer prevents random or attacker provoked computation errors. This prevents publishing invalid signatures which may leak information about the secret key. It is recommended but can be omitted if the computation cost is prohibitive.</ref>
 * Return partial signature ''psig''
 </div>
 
@@ -725,7 +725,7 @@ The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed t
 </poem>
 
 <poem>
-The verifier doesn't have access to ''d⋅G'', but can construct it using the individual public key ''pk'' as follows:
+The verifier doesn't have access to ''d⋅G'' but can construct it using the individual public key ''pk'' as follows:
 ''d⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅d'⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅cpoint(pk)''

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -47,7 +47,7 @@ The MuSig2 variant proposed below stands out by combining all the following feat
 === Design ===
 
 * '''Compatibility with BIP340''': In this proposal, the aggregate public key is a BIP340 X-only public key, and the signature output at the end of the signing protocol is a BIP340 signature that passes BIP340 verification for the aggregate public key and a message. The public keys that are input to the key aggregation algorithm are ''plain'' public keys in compressed format.
-* '''Tweaking for BIP32 derivations and Taproot''': This proposal supports tweaking aggregate public keys and signing for tweaked aggregate public keys. We distinguish two modes of tweaking: ''Plain'' tweaking can be used to derive child aggregate public keys per [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32]. ''X-only'' tweaking, on the other hand, allows creating a [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] tweak to add script paths to a Taproot output. See section [[#tweaking|Tweaking]] below for details.
+* '''Tweaking for BIP32 derivations and Taproot''': This proposal supports tweaking aggregate public keys and signing for tweaked aggregate public keys. We distinguish two modes of tweaking: ''Plain'' tweaking can be used to derive child aggregate public keys per [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32]. ''X-only'' tweaking, on the other hand, allows creating a [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] tweak to add script paths to a Taproot output. See [[#tweaking-the-aggregate-public-key|below]] for details.
 * '''Non-interactive signing with preprocessing''': The first communication round, exchanging the nonces, can happen before the message or the exact set of signers is determined. Once the parameters of the signing session are finalized, the signers can send partial signatures without additional interaction.
 * '''Key aggregation optionally independent of order''': The output of the key aggregation algorithm depends on the order of the input public keys. Key aggregation does not sort the public keys by default because applications often already have a canonical order of signers. Nonetheless, applications can mandate sorting before aggregation,<ref>Applications that sort input public keys before aggregation should ensure that the implementation of sorting is reasonably efficient, and in particular does not degenerate to quadratic runtime on pathological inputs.</ref> and this proposal specifies a canonical order to sort the public keys before key aggregation. Sorting will ensure the same output, independent of the initial order.
 * '''Third-party nonce and partial signature aggregation''': Instead of every signer sending their nonce and partial signature to every other signer, it is possible to use an untrusted third-party ''aggregator'' in order to reduce the communication complexity from quadratic to linear in the number of signers. In each of the two rounds, the aggregator collects all signers' contributions (nonces or partial signatures), aggregates them, and broadcasts the aggregate back to the signers. A malicious aggregator can force the signing session to fail to produce a valid Schnorr signature but cannot negatively affect the unforgeability of the scheme.
@@ -107,10 +107,10 @@ Plain public keys are byte strings of length 33 (often called ''compressed'' for
 In contrast, X-only public keys are 32-byte strings defined in [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340].
 
 The individual public keys of signers as input to the key aggregation algorithm ''KeyAgg'' (and to ''GetSessionValues'' and ''PartialSigVerify'') are plain public keys.
-The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate public key (see [[#tweaking|below]]),
+The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate public key (see [[#tweaking-the-aggregate-public-key|below]]),
 and it can be used to produce an X-only aggregate public key, or a plain aggregate public key.
 In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
-To get the plain aggregate public key, which is required for some applications of [[#tweaking|tweaking]], implementations call ''GetPlainPubkey'' instead.
+To get the plain aggregate public key, which is required for some applications of [[#tweaking-the-aggregate-public-key|tweaking]], implementations call ''GetPlainPubkey'' instead.
 
 The aggregate public key produced by ''KeyAgg'' is dependent on the order of the input public keys.
 If the application does not have a canonical order of the signers, the public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate public key is independent of the order of signers.
@@ -181,7 +181,7 @@ In particular, partial signatures are ''not'' signatures.
 An adversary can forge a partial signature, i.e., create a partial signature without knowing the secret key for the claimed public key.<ref>Assume an adversary wants to forge a partial signature for public key ''P''. It joins the signing session pretending to be two different signers, one with public key ''P'' and one with another public key. The adversary can then set the second signer's nonce such that it will be able to produce a partial signature for ''P'', but not for the other claimed signer. An explanation of the individual steps required to create a partial signature forgery can be found in [https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b a write up by Adam Gibson].</ref>
 However, if ''PartialSigVerify'' succeeds for all partial signatures then ''PartialSigAgg'' will return a valid Schnorr signature.<ref>Given a list of public keys, it is an open question whether a valid BIP-340 signature for the aggregate of the public keys is proof of knowledge of the secret keys corresponding to the input list.</ref>
 
-=== Tweaking ===
+=== Tweaking the Aggregate Public Key ===
 
 The aggregate public key can be ''tweaked'', which modifies the key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
 In order to apply a tweak, the KeyGen Context output by ''KeyAgg'' is provided to the ''ApplyTweak'' algorithm with the ''is_xonly_t'' argument set to false for plain tweaking and true for X-only tweaking.
@@ -634,7 +634,7 @@ Algorithm ''DeterministicSign(sk, aggothernonce, pk<sub>1..u</sub>, tweak<sub>1.
 
 === Tweaking Definition ===
 
-Two modes of tweaking are supported. They correspond to the following algorithms:
+Two modes of tweaking the aggregate public key are supported. They correspond to the following algorithms:
 
 <div>
 Algorithm ''ApplyPlainTweak(P, t)'':

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -102,14 +102,15 @@ This party would have complete control over the aggregate public key and message
 
 === Public Key Aggregation  ===
 
-We distinguish between ''plain public keys'', the traditional key type used in Bitcoin, and ''x-only public keys''.
+We distinguish between two public key types, namely ''plain public keys'', the key type traditionally used in Bitcoin, and ''X-only public keys''.
 Plain public keys are byte strings of length 33 (often called ''compressed'' format).
 In contrast, X-only public keys are 32-byte strings defined in [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340].
 
-The input of the key aggregation algorithm ''KeyAgg'' (and of ''GetSessionValues'' and ''PartialSigVerify'') are plain public keys.
-The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking (see [[#tweaking|below]]).
-In order to obtain the (X-only) aggregate public key for BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
-It is also possible to get the plain aggregate public from the KeyGen Context using ''GetPlainPubkey'', which is required for some applications of [[#tweaking|tweaking]].
+The individual public keys of signers as input to the key aggregation algorithm ''KeyAgg'' (and to ''GetSessionValues'' and ''PartialSigVerify'') are plain public keys.
+The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate key (see [[#tweaking|below]]),
+and it can be used to produce an X-only aggregate public key, or a plain aggregate public key.
+In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
+To get the plain aggregate public key, which is required for some applications of [[#tweaking|tweaking]], implementations call ''GetPlainPubkey'' instead.
 
 The aggregate key produced by ''KeyAgg'' is dependent on the order of the input public keys.
 If the application does not have a canonical order of the signers, the public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate key is independent of the order of signers.
@@ -287,7 +288,7 @@ Algorithm ''GetPlainPubkey(keygen_ctx)'':
 Algorithm ''KeySort(pk<sub>1..u</sub>)'':
 * Inputs:
 ** The number ''u'' of public keys with ''0 < u < 2^32''
-** The plain public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
+** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * Return ''pk<sub>1..u</sub>'' sorted in lexicographical order.
 </div>
 
@@ -297,7 +298,7 @@ Algorithm ''KeySort(pk<sub>1..u</sub>)'':
 Algorithm ''KeyAgg(pk<sub>1..u</sub>)'':
 * Inputs:
 ** The number ''u'' of public keys with ''0 < u < 2^32''
-** The plain public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
+** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * Let ''pk2 = GetSecondKey(pk<sub>1..u</sub>)''
 * For ''i = 1 .. u'':
 ** Let ''P<sub>i</sub> = cpoint(pk<sub>i</sub>)''; fail if that fails and blame signer ''i'' for invalid public key.
@@ -363,7 +364,7 @@ Algorithm ''ApplyTweak(keygen_ctx, tweak, is_xonly_t)'':
 Algorithm ''NonceGen(sk, pk, aggpk, m, extra_in)'':
 * Inputs:
 ** The secret signing key ''sk'': a 32-byte array (optional argument)
-** The plain public key ''pk'': a 33-byte array (see [[#modifications-to-nonce-generation|Modifications to Nonce Generation]] for the reason that this argument is mandatory)
+** The individual public key ''pk'': a 33-byte array (see [[#modifications-to-nonce-generation|Modifications to Nonce Generation]] for the reason that this argument is mandatory)
 ** The aggregate x-only public key ''aggpk'': a 32-byte array (optional argument)
 ** The message ''m'': a byte array (optional argument)<ref name="mlen">In theory, the allowed message size is restricted because SHA256 accepts byte strings only up to size of 2^61-1 bytes (and because of the 8-byte length encoding).</ref>
 ** The auxiliary input ''extra_in'': a byte array with ''0 &le; len(extra_in) &le; 2<sup>32</sup>-1'' (optional argument)
@@ -407,7 +408,7 @@ Algorithm ''NonceAgg(pubnonce<sub>1..u</sub>)'':
 The Session Context is a data structure consisting of the following elements:
 * The aggregate public nonce ''aggnonce'': a 66-byte array
 * The number ''u'' of public keys with ''0 < u < 2^32''
-* The plain public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
+* The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * The number ''v'' of tweaks with ''0 &le; v < 2^32''
 * The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 * The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
@@ -476,7 +477,7 @@ Algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, t
 ** The partial signature ''psig'': a 32-byte array
 ** The number ''u'' of public nonces and public keys with ''0 < u < 2^32''
 ** The public nonces ''pubnonce<sub>1..u</sub>'': ''u'' 66-byte arrays
-** The plain public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
+** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 ** The number ''v'' of tweaks with ''0 &le; v < 2^32''
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 ** The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
@@ -559,7 +560,7 @@ then it is not a problem that the attacker can influence this decision after hav
 More formally, consider modified algorithms ''NonceGen' '' and ''Sign' '', where ''NonceGen' '' does not take the individual public key of the signer as input and does not store it in pubnonce, and Sign' does not check read the individual public key from pubnonce and does not check it against the secret key taken as input.
 Then it suffices that for each invocation of ''NonceGen' '' with output ''(secnonce, pubnonce)'',
 a function ''fsk'' is determined before sending out ''pubnonce'',
-where ''fsk'' maps a pair consisting of a list of plain public keys and a message to a secret key,
+where ''fsk'' maps a pair consisting of a list of individual public keys and a message to a secret key,
 such that the secret key ''sk'' and the session context ''session_ctx = (_, _, pk<sub>1..u</sub>, _, _, _, m)''
 provided to the corresponding invocation of ''Sign'(secnonce, sk, session_ctx)'',
 adhere to the condition ''fsk(pk<sub>1..u</sub>, m) = sk''.<br />
@@ -604,7 +605,7 @@ Algorithm ''DeterministicSign(sk, aggothernonce, pk<sub>1..u</sub>, tweak<sub>1.
 ** The secret signing key ''sk'': a 32-byte array
 ** The aggregate public nonce ''aggothernonce'' (see [[#modifications-to-nonce-generation|above]]): a 66-byte array
 ** The number ''u'' of public keys with ''0 < u < 2^32''
-** The plain public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
+** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 ** The number ''v'' of tweaks with ''0 &le; v < 2^32''
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 ** The tweak methods ''is_xonly_t<sub>1..v</sub>'': ''v'' booleans
@@ -650,11 +651,11 @@ Algorithm ''ApplyXonlyTweak(P, t)'':
 
 === Negation Of The Secret Key When Signing ===
 
-In order to produce a partial signature for an X-only public key that is an aggregate of ''u'' plain public keys and tweaked ''v'' times (X-only or plain), the ''[[#Sign negation|Sign]]'' algorithm may need to negate the secret key during the signing process.
+In order to produce a partial signature for an X-only public key that is an aggregate of ''u'' individual public keys and tweaked ''v'' times (X-only or plain), the ''[[#Sign negation|Sign]]'' algorithm may need to negate the secret key during the signing process.
 
 <poem>
 The following elliptic curve points arise as intermediate steps when creating a signature:
-• ''P<sub>i</sub>'' as computed in ''KeyAgg'' is the point corresponding to the ''i''-th signer's plain public key. Defining ''d<sub>i</sub>' '' to be the ''i''-th signer's secret key as an integer, i.e., the ''d' '' value as computed in the ''Sign'' algorithm of the ''i''-th signer, we have
+• ''P<sub>i</sub>'' as computed in ''KeyAgg'' is the point corresponding to the ''i''-th signer's individual public key. Defining ''d<sub>i</sub>' '' to be the ''i''-th signer's secret key as an integer, i.e., the ''d' '' value as computed in the ''Sign'' algorithm of the ''i''-th signer, we have
     ''P<sub>i</sub> = d<sub>i</sub>'⋅G ''.
 • ''Q<sub>0</sub>'' is the aggregate of the signers' public keys. It is identical to value ''Q'' computed in ''KeyAgg'' and therefore defined as
     ''Q<sub>0</sub> = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>2</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''.
@@ -724,7 +725,7 @@ The ''[[#SigVerify negation|PartialSigVerifyInternal]]'' algorithm is supposed t
 </poem>
 
 <poem>
-The verifier doesn't have access to ''d⋅G'', but can construct it using the plain public key ''pk'' as follows:
+The verifier doesn't have access to ''d⋅G'', but can construct it using the individual public key ''pk'' as follows:
 ''d⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅d'⋅G
     = g<sub>v</sub>⋅gacc<sub>v</sub>⋅cpoint(pk)''

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -29,7 +29,7 @@ Signing requires interaction between ''all'' signers involved in key aggregation
 (MuSig2 is a ''n-of-n'' multi-signature scheme and not a ''t-of-n'' threshold-signature scheme.)
 
 The primary motivation is to create a standard that allows users of different software projects to jointly control Taproot outputs ([https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341]).
-Such an output contains a public key which, in this case, would be the aggregate of all users' public keys.
+Such an output contains a public key which, in this case, would be the aggregate of all users' individual public keys.
 It can be spent using MuSig2 to produce a signature for the key-based spending path.
 
 The on-chain footprint of a MuSig2 Taproot output is essentially a single BIP340 public key, and a transaction spending the output only requires a single signature cooperatively produced by all signers. This is '''more compact''' and has '''lower verification cost''' than each signer providing an individual public key and signature, as would be required by an ''n-of-n'' policy implemented using <code>OP_CHECKSIGADD</code> as introduced in ([https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki BIP342]).
@@ -46,13 +46,13 @@ The MuSig2 variant proposed below stands out by combining all the following feat
 
 === Design ===
 
-* '''Compatibility with BIP340''': In this proposal, the aggregate public key is a BIP340 X-only public key, and the signature output at the end of the signing protocol is a BIP340 signature that passes BIP340 verification for the aggregate public key and a message. The public keys that are input to the key aggregation algorithm are ''plain'' public keys in compressed format.
+* '''Compatibility with BIP340''': In this proposal, the aggregate public key is a BIP340 X-only public key, and the signature output at the end of the signing protocol is a BIP340 signature that passes BIP340 verification for the aggregate public key and a message. The individual public keys that are input to the key aggregation algorithm are ''plain'' public keys in compressed format.
 * '''Tweaking for BIP32 derivations and Taproot''': This proposal supports tweaking aggregate public keys and signing for tweaked aggregate public keys. We distinguish two modes of tweaking: ''Plain'' tweaking can be used to derive child aggregate public keys per [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32]. ''X-only'' tweaking, on the other hand, allows creating a [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341] tweak to add script paths to a Taproot output. See [[#tweaking-the-aggregate-public-key|below]] for details.
 * '''Non-interactive signing with preprocessing''': The first communication round, exchanging the nonces, can happen before the message or the exact set of signers is determined. Once the parameters of the signing session are finalized, the signers can send partial signatures without additional interaction.
-* '''Key aggregation optionally independent of order''': The output of the key aggregation algorithm depends on the order of the input public keys. Key aggregation does not sort the public keys by default because applications often already have a canonical order of signers. Nonetheless, applications can mandate sorting before aggregation,<ref>Applications that sort input public keys before aggregation should ensure that the implementation of sorting is reasonably efficient, and in particular does not degenerate to quadratic runtime on pathological inputs.</ref> and this proposal specifies a canonical order to sort the public keys before key aggregation. Sorting will ensure the same output, independent of the initial order.
+* '''Key aggregation optionally independent of order''': The output of the key aggregation algorithm depends on the order in which the individual public keys are provided as input. Key aggregation does not sort the individual public keys by default because applications often already have a canonical order of signers. Nonetheless, applications can mandate sorting before aggregation,<ref>Applications that sort individual public keys before aggregation should ensure that the implementation of sorting is reasonably efficient, and in particular does not degenerate to quadratic runtime on pathological inputs.</ref> and this proposal specifies a canonical order to sort the individual public keys before key aggregation. Sorting will ensure the same output, independent of the initial order.
 * '''Third-party nonce and partial signature aggregation''': Instead of every signer sending their nonce and partial signature to every other signer, it is possible to use an untrusted third-party ''aggregator'' in order to reduce the communication complexity from quadratic to linear in the number of signers. In each of the two rounds, the aggregator collects all signers' contributions (nonces or partial signatures), aggregates them, and broadcasts the aggregate back to the signers. A malicious aggregator can force the signing session to fail to produce a valid Schnorr signature but cannot negatively affect the unforgeability of the scheme.
 * '''Partial signature verification''': If any signer sends a partial signature contribution that was not created by honestly following the signing protocol, the signing session will fail to produce a valid Schnorr signature. This proposal specifies a partial signature verification algorithm to identify disruptive signers. It is incompatible with third-party nonce aggregation because the individual nonce is required for partial verification.
-* '''MuSig2* optimization''': This proposal uses an optimized scheme MuSig2*, which allows saving a point multiplication in key aggregation as compared to MuSig2. MuSig2* is proven secure in the appendix of the [https://eprint.iacr.org/2020/1261 MuSig2 paper]. The optimization consists of assigning the constant key aggregation coefficient ''1'' to the second distinct key in the list of public keys to be aggregated (as well as to any key identical to this key).
+* '''MuSig2* optimization''': This proposal uses an optimized scheme MuSig2*, which allows saving a point multiplication in key aggregation as compared to MuSig2. MuSig2* is proven secure in the appendix of the [https://eprint.iacr.org/2020/1261 MuSig2 paper]. The optimization consists of assigning the constant key aggregation coefficient ''1'' to the second distinct key in the list of individual public keys to be aggregated (as well as to any key identical to this key).
 * '''Size of the nonce and security''': In this proposal, each signer's nonce consists of two elliptic curve points. The [https://eprint.iacr.org/2020/1261 MuSig2 paper] gives distinct security proofs depending on the number of points that constitute a nonce. See section [[#choosing-the-size-of-the-nonce|Choosing the Size of the Nonce]] for a discussion.
 
 == Overview ==
@@ -68,13 +68,13 @@ Such optional features include:
 * Applying tweaks at all.
 * Dealing with messages that are not exactly 32 bytes.
 * Identifying a disruptive signer after aborting (aborting itself remains mandatory).
-* Dealing with duplicate public keys in key aggregation.
+* Dealing with duplicate individual public keys in key aggregation.
 If applicable, the corresponding algorithms should simply fail when encountering inputs unsupported by a particular implementation. (For example, the signing algorithm may fail when given a message which is not 32 bytes.)
 Similarly, the test vectors that exercise the unimplemented features should be re-interpreted to expect an error, or be skipped if appropriate.
 
 === General Signing Flow ===
 
-The signers start by exchanging public keys and computing an aggregate public key using the ''KeyAgg'' algorithm.
+The signers start by exchanging their individual public keys and computing an aggregate public key using the ''KeyAgg'' algorithm.
 Whenever they want to sign a message, the basic order of operations to create a multi-signature is as follows:
 
 '''First broadcast round:'''
@@ -112,20 +112,20 @@ and it can be used to produce an X-only aggregate public key, or a plain aggrega
 In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
 To get the plain aggregate public key, which is required for some applications of [[#tweaking-the-aggregate-public-key|tweaking]], implementations call ''GetPlainPubkey'' instead.
 
-The aggregate public key produced by ''KeyAgg'' is dependent on the order of the input public keys.
-If the application does not have a canonical order of the signers, the public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate public key is independent of the order of signers.
+The aggregate public key produced by ''KeyAgg'' (regardless of the type) depends on the order of the individual public keys.
+If the application does not have a canonical order of the signers, the individual public keys can be sorted with the ''KeySort'' algorithm to ensure that the aggregate public key is independent of the order of signers.
 
-The same public key is allowed to occur more than once in the input of ''KeyAgg'' and ''KeySort''.
-This is by design: All algorithms in this proposal handle multiple signers who (claim to) have identical public keys properly,
-and applications are not required to check for duplicate public keys.
-In fact, applications are recommended to omit checks for duplicate public keys in order to simplify error handling.
-Moreover, it is often impossible to tell at key aggregation which signer is to blame for the duplicate, i.e., which signer came up with the public key honestly and which disruptive signer copied it.
+The same individual public key is allowed to occur more than once in the input of ''KeyAgg'' and ''KeySort''.
+This is by design: All algorithms in this proposal handle multiple signers who (claim to) have identical individual public keys properly,
+and applications are not required to check for duplicate individual public keys.
+In fact, applications are recommended to omit checks for duplicate individual public keys in order to simplify error handling.
+Moreover, it is often impossible to tell at key aggregation which signer is to blame for the duplicate, i.e., which signer came up with an individual public key honestly and which disruptive signer copied it.
 In contrast, MuSig2 is designed to identify disruptive signers at signing time (see [[#identifiying-disruptive-signers|Identifiying Disruptive Signers]]).
 
-While the algorithms in this proposal are able to handle duplicate public keys, there are scenarios where applications may choose to abort when encountering duplicate public keys.
+While the algorithms in this proposal are able to handle duplicate individual public keys, there are scenarios where applications may choose to abort when encountering duplicates.
 For example, we can imagine a scenario where a single entity creates a MuSig2 setup with multiple signing devices.
-In that case, duplicate public keys may not result from a malicious signing device copying a public key of another signing device but from accidental initialization of two devices with the same seed.
-Since MuSig2 key aggregation would accept the duplicate keys and not error out, which would in turn reduce the security compared to the intended key setup, applications may reject duplicate public keys before passing them to MuSig2 key aggregation and ask the user to investigate.
+In that case, duplicates may not result from a malicious signing device copying an individual public key of another signing device but from accidental initialization of two devices with the same seed.
+Since MuSig2 key aggregation would accept the duplicate keys and not error out, which would in turn reduce the security compared to the intended key setup, applications may reject duplicate individual public keys before passing them to MuSig2 key aggregation and ask the user to investigate.
 
 === Nonce Generation ===
 
@@ -140,7 +140,7 @@ e.g., a supposedly unique session id (taken from the application), a session cou
 However, the protection provided by the optional arguments should only be viewed as a last resort.
 In most conceivable scenarios, the assumption that the arguments are different between two executions of ''NonceGen'' is relatively strong, particularly when facing an active attacker.
 
-In some applications, it is beneficial to generate and send a ''pubnonce'' before the other signers, their public keys, or the message to sign is known.
+In some applications, it is beneficial to generate and send a ''pubnonce'' before the other signers, their individual public keys, or the message to sign is known.
 In this case, only the available arguments are provided to the ''NonceGen'' algorithm.
 After this preprocessing phase, the ''Sign'' algorithm can be run immediately when the message and set of signers is determined.
 This way, the final signature is created quicker and with fewer round trips.
@@ -153,7 +153,7 @@ A malicious aggregator can force the signing session to fail to produce a valid 
 
 In general, MuSig2 signers are stateful in the sense that they first generate ''secnonce'' and then need to store it until they receive the other signers' ''pubnonces'' or the ''aggnonce''.
 However, it is possible for one of the signers to be stateless.
-This signer waits until it receives the ''pubnonce'' of all the other signers and until session parameters such as a message to sign, public keys, and tweaks are determined.
+This signer waits until it receives the ''pubnonce'' of all the other signers and until session parameters such as a message to sign, individual public keys, and tweaks are determined.
 Then, the signer can run ''NonceGen'', ''NonceAgg'' and ''Sign'' in sequence and send out its ''pubnonce'' along with its partial signature.
 Stateless signers may want to consider signing deterministically (see [[#modifications-to-nonce-generation|Modifications to Nonce Generation]]) to remove the reliance on the random number generator in the ''NonceGen'' algorithm.
 
@@ -178,8 +178,8 @@ More specifically, a malicious aggregator (whose existence violates the second c
 
 The only purpose of the algorithm ''PartialSigVerify'' is to ensure identifiable aborts, and it is not necessary to use it when identifiable aborts are not desired.
 In particular, partial signatures are ''not'' signatures.
-An adversary can forge a partial signature, i.e., create a partial signature without knowing the secret key for the claimed public key.<ref>Assume an adversary wants to forge a partial signature for public key ''P''. It joins the signing session pretending to be two different signers, one with public key ''P'' and one with another public key. The adversary can then set the second signer's nonce such that it will be able to produce a partial signature for ''P'' but not for the other claimed signer. An explanation of the individual steps required to create a partial signature forgery can be found in [https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b a write up by Adam Gibson].</ref>
-However, if ''PartialSigVerify'' succeeds for all partial signatures then ''PartialSigAgg'' will return a valid Schnorr signature.<ref>Given a list of public keys, it is an open question whether a valid BIP-340 signature for the aggregate of the public keys is proof of knowledge of the secret keys corresponding to the input list.</ref>
+An adversary can forge a partial signature, i.e., create a partial signature without knowing the secret key for the claimed individual public key.<ref>Assume an adversary wants to forge a partial signature for individual public key ''P''. It joins the signing session pretending to be two different signers, one with individual public key ''P'' and one with another individual public key. The adversary can then set the second signer's nonce such that it will be able to produce a partial signature for ''P'' but not for the other claimed signer. An explanation of the individual steps required to create a partial signature forgery can be found in [https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b a write up by Adam Gibson].</ref>
+However, if ''PartialSigVerify'' succeeds for all partial signatures then ''PartialSigAgg'' will return a valid Schnorr signature.<ref>Given a list of individual public keys, it is an open question whether a valid BIP-340 signature for the corresponding aggregate public key is proof of knowledge of the secret keys corresponding to the input list.</ref>
 
 === Tweaking the Aggregate Public Key ===
 
@@ -187,8 +187,8 @@ The aggregate public key can be ''tweaked'', which modifies the key as defined i
 In order to apply a tweak, the KeyGen Context output by ''KeyAgg'' is provided to the ''ApplyTweak'' algorithm with the ''is_xonly_t'' argument set to false for plain tweaking and true for X-only tweaking.
 The resulting KeyGen Context can be used to apply another tweak with ''ApplyTweak'' or obtain the aggregate public key with ''GetXonlyPubkey'' or ''GetPlainPubkey''.
 
-In addition to public keys, the ''KeyAgg'' algorithm accepts tweaks, which modify the aggregate public key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
-For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate public key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
+In addition to individual public keys, the ''KeyAgg'' algorithm accepts tweaks, which modify the aggregate public key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
+For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
 
 The purpose of supporting tweaking is to ensure compatibility with existing uses of tweaking, i.e., that the result of signing is a valid signature for the tweaked public key.
 The MuSig2 algorithms take arbitrary tweaks as input but accepting arbitrary tweaks may negatively affect the security of the scheme.<ref>It is an open question whether allowing arbitrary tweaks from an adversary affects the unforgeability of MuSig2.</ref>
@@ -201,7 +201,7 @@ The tweak mode provided to ''ApplyTweak'' depends on the application:
 Plain tweaking can be used to derive child public keys from an aggregate public key using [https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki BIP32].
 On the other hand, X-only tweaking is required for Taproot tweaking per [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341].
 A Taproot-tweaked public key commits to a ''script path'', allowing users to create transaction outputs that are spendable either with a MuSig2 multi-signature or by providing inputs that satisfy the script path.
-Script path spends require a control block that contains a parity bit for the tweaked public key.
+Script path spends require a control block that contains a parity bit for the tweaked X-only public key.
 The bit can be obtained with ''GetPlainPubkey(keygen_ctx)[0] & 1''.
 
 == Algorithms ==
@@ -264,7 +264,7 @@ Algorithm ''IndividualPubkey(sk)'':<ref>The ''IndividualPubkey'' algorithm match
 ==== KeyGen Context ====
 
 The KeyGen Context is a data structure consisting of the following elements:
-* The point ''Q'' representing the aggregate and potentially tweaked public key: an elliptic curve point
+* The point ''Q'' representing the potentially tweaked aggregate public key: an elliptic curve point
 * The accumulated tweak ''tacc'': an integer with ''0 &le; tacc < n''
 * The value ''gacc'' : 1 or -1 mod n
 
@@ -287,7 +287,7 @@ Algorithm ''GetPlainPubkey(keygen_ctx)'':
 <div>
 Algorithm ''KeySort(pk<sub>1..u</sub>)'':
 * Inputs:
-** The number ''u'' of public keys with ''0 < u < 2^32''
+** The number ''u'' of individual public keys with ''0 < u < 2^32''
 ** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * Return ''pk<sub>1..u</sub>'' sorted in lexicographical order.
 </div>
@@ -297,11 +297,11 @@ Algorithm ''KeySort(pk<sub>1..u</sub>)'':
 <div>
 Algorithm ''KeyAgg(pk<sub>1..u</sub>)'':
 * Inputs:
-** The number ''u'' of public keys with ''0 < u < 2^32''
+** The number ''u'' of individual public keys with ''0 < u < 2^32''
 ** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * Let ''pk2 = GetSecondKey(pk<sub>1..u</sub>)''
 * For ''i = 1 .. u'':
-** Let ''P<sub>i</sub> = cpoint(pk<sub>i</sub>)''; fail if that fails and blame signer ''i'' for invalid public key.
+** Let ''P<sub>i</sub> = cpoint(pk<sub>i</sub>)''; fail if that fails and blame signer ''i'' for invalid individual public key.
 ** Let ''a<sub>i</sub> = KeyAggCoeffInternal(pk<sub>1..u</sub>, pk<sub>i</sub>, pk2)''.
 * Let ''Q = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>2</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''
 * Fail if ''is_infinite(Q)''.
@@ -334,7 +334,7 @@ Internal Algorithm ''KeyAggCoeffInternal(pk<sub>1..u</sub>, pk', pk2)'':
 * Let ''L = HashKeys(pk<sub>1..u</sub>)''
 * If ''pk' = pk2'':
 ** Return 1
-* Return ''int(hash<sub>KeyAgg coefficient</sub>(L || pk')) mod n''<ref>The key aggregation coefficient is computed by hashing the public key instead of its index, which requires one more invocation of the SHA-256 compression function. However, it results in significantly simpler implementations because signers do not need to translate between public key indices before and after sorting.</ref>
+* Return ''int(hash<sub>KeyAgg coefficient</sub>(L || pk')) mod n''<ref>The key aggregation coefficient is computed by hashing the individual public key instead of its index, which requires one more invocation of the SHA-256 compression function. However, it results in significantly simpler implementations because signers do not need to translate between public key indices before and after sorting.</ref>
 </div>
 
 ==== Applying Tweaks ====
@@ -365,7 +365,7 @@ Algorithm ''NonceGen(sk, pk, aggpk, m, extra_in)'':
 * Inputs:
 ** The secret signing key ''sk'': a 32-byte array (optional argument)
 ** The individual public key ''pk'': a 33-byte array (see [[#modifications-to-nonce-generation|Modifications to Nonce Generation]] for the reason that this argument is mandatory)
-** The aggregate x-only public key ''aggpk'': a 32-byte array (optional argument)
+** The x-only aggregate public key ''aggpk'': a 32-byte array (optional argument)
 ** The message ''m'': a byte array (optional argument)<ref name="mlen">In theory, the allowed message size is restricted because SHA256 accepts byte strings only up to size of 2^61-1 bytes (and because of the 8-byte length encoding).</ref>
 ** The auxiliary input ''extra_in'': a byte array with ''0 &le; len(extra_in) &le; 2<sup>32</sup>-1'' (optional argument)
 * Let ''rand' '' be a 32-byte array freshly drawn uniformly at random
@@ -407,7 +407,7 @@ Algorithm ''NonceAgg(pubnonce<sub>1..u</sub>)'':
 
 The Session Context is a data structure consisting of the following elements:
 * The aggregate public nonce ''aggnonce'': a 66-byte array
-* The number ''u'' of public keys with ''0 < u < 2^32''
+* The number ''u'' of individual public keys with ''0 < u < 2^32''
 * The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 * The number ''v'' of tweaks with ''0 &le; v < 2^32''
 * The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
@@ -475,14 +475,14 @@ Algorithm ''Sign(secnonce, sk, session_ctx)'':
 Algorithm ''PartialSigVerify(psig, pubnonce<sub>1..u</sub>, pk<sub>1..u</sub>, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m, i)'':
 * Inputs:
 ** The partial signature ''psig'': a 32-byte array
-** The number ''u'' of public nonces and public keys with ''0 < u < 2^32''
+** The number ''u'' of public nonces and individual public keys with ''0 < u < 2^32''
 ** The public nonces ''pubnonce<sub>1..u</sub>'': ''u'' 66-byte arrays
 ** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 33-byte arrays
 ** The number ''v'' of tweaks with ''0 &le; v < 2^32''
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
 ** The tweak modes ''is_xonly_t<sub>1..v</sub>'' : ''v'' booleans
 ** The message ''m'': a byte array<ref name="mlen" />
-** The index of the signer ''i'' in the public nonces and public keys with ''0 < i &le; u''
+** The index of the signer ''i'' in the of public nonces and individual public keys with ''0 < i &le; u''
 * Let ''aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)''; fail if that fails
 * Let ''session_ctx = (aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)''
 * Run ''PartialSigVerifyInternal(psig, pubnonce<sub>i</sub>, pk<sub>i</sub>, session_ctx)''
@@ -499,7 +499,7 @@ Internal Algorithm ''PartialSigVerifyInternal(psig, pubnonce, pk, session_ctx)''
 * Let ''P = cpoint(pk)''; fail if that fails
 * Let ''a = GetSessionKeyAggCoeff(session_ctx, P)''<ref>''GetSessionKeyAggCoeff(session_ctx, P)'' cannot fail when called from ''PartialSigVerifyInternal''.</ref>
 * Let ''g = 1'' if ''has_even_y(Q)'', otherwise let ''g = -1 mod n''
-* <div id="SigVerify negation"></div>Let ''g' = g⋅gacc mod n'' (See [[#negation-of-the-public-key-when-partially-verifying|Negation Of The Public Key When Partially Verifying]])
+* <div id="SigVerify negation"></div>Let ''g' = g⋅gacc mod n'' (See [[#negation-of-the-individual-public-key-when-partially-verifying|Negation Of The Individual Public Key When Partially Verifying]])
 * Fail if ''s⋅G &ne; Re<sub>⁎</sub> + e⋅a⋅g'⋅P''
 * Return success iff no failure occurred before reaching this point.
 </div>
@@ -555,7 +555,7 @@ that the secret key provided to ''Sign'' is fully determined already when ''Nonc
 This removes the adversary's ability to influence the secret key after having seen the ''pubnonce''
 and thus rules out the attack.<ref>Ensuring that the secret key provided to ''Sign'' is fully determined already when ''NonceGen'' is invoked is a simple policy to rule out the attack,
 but more flexible polices are conceivable.
-In fact, if the signer uses nothing but the message to be signed and the list of the public keys of all signers to decide which secret key to use,
+In fact, if the signer uses nothing but the message to be signed and the list of the individual public keys of all signers to decide which secret key to use,
 then it is not a problem that the attacker can influence this decision after having seen the ''pubnonce''.<br />
 More formally, consider modified algorithms ''NonceGen' '' and ''Sign' '', where ''NonceGen' '' does not take the individual public key of the signer as input and does not store it in pubnonce, and Sign' does not check read the individual public key from pubnonce and does not check it against the secret key taken as input.
 Then it suffices that for each invocation of ''NonceGen' '' with output ''(secnonce, pubnonce)'',
@@ -567,7 +567,7 @@ adhere to the condition ''fsk(pk<sub>1..u</sub>, m) = sk''.<br />
 However, this requirement is complex and hard to enforce in implementations.
 The algorithms ''NonceGen'' and ''Sign'' specified in this BIP are effectively restricted to constant functions ''fsk(_, _) = sk''.
 In other words, their usage ensure that the secret key ''sk'' of the signers is determined entirely when invoking ''NonceGen'',
-which is enforced easily by letting ''NonceGen'' take the corresponding public key ''pk'' as input and checking  ''pk'' against ''IndividualPubKey(sk)'' in ''Sign''.</ref>
+which is enforced easily by letting ''NonceGen'' take the corresponding individual public key ''pk'' as input and checking  ''pk'' against ''IndividualPubKey(sk)'' in ''Sign''.</ref>
 Note that the scheme as given in the [https://eprint.iacr.org/2020/1261 MuSig2 paper] does not perform the check in ''Sign''.
 However, the security model in the paper does not cover tweaking at all and assumes a single fixed secret key.
 
@@ -604,7 +604,7 @@ Algorithm ''DeterministicSign(sk, aggothernonce, pk<sub>1..u</sub>, tweak<sub>1.
 * Inputs:
 ** The secret signing key ''sk'': a 32-byte array
 ** The aggregate public nonce ''aggothernonce'' (see [[#modifications-to-nonce-generation|above]]): a 66-byte array
-** The number ''u'' of public keys with ''0 < u < 2^32''
+** The number ''u'' of individual public keys with ''0 < u < 2^32''
 ** The individual public keys ''pk<sub>1..u</sub>'': ''u'' 32-byte arrays
 ** The number ''v'' of tweaks with ''0 &le; v < 2^32''
 ** The tweaks ''tweak<sub>1..v</sub>'': ''v'' 32-byte arrays
@@ -651,15 +651,15 @@ Algorithm ''ApplyXonlyTweak(P, t)'':
 
 === Negation Of The Secret Key When Signing ===
 
-In order to produce a partial signature for an X-only public key that is an aggregate of ''u'' individual public keys and tweaked ''v'' times (X-only or plain), the ''[[#Sign negation|Sign]]'' algorithm may need to negate the secret key during the signing process.
+In order to produce a partial signature for an X-only aggregate public key that is an aggregate of ''u'' individual public keys and tweaked ''v'' times (X-only or plain), the ''[[#Sign negation|Sign]]'' algorithm may need to negate the secret key during the signing process.
 
 <poem>
 The following elliptic curve points arise as intermediate steps when creating a signature:
 • ''P<sub>i</sub>'' as computed in ''KeyAgg'' is the point corresponding to the ''i''-th signer's individual public key. Defining ''d<sub>i</sub>' '' to be the ''i''-th signer's secret key as an integer, i.e., the ''d' '' value as computed in the ''Sign'' algorithm of the ''i''-th signer, we have
     ''P<sub>i</sub> = d<sub>i</sub>'⋅G ''.
-• ''Q<sub>0</sub>'' is the aggregate of the signers' public keys. It is identical to value ''Q'' computed in ''KeyAgg'' and therefore defined as
+• ''Q<sub>0</sub>'' is the aggregate of the individual public keys. It is identical to value ''Q'' computed in ''KeyAgg'' and therefore defined as
     ''Q<sub>0</sub> = a<sub>1</sub>⋅P<sub>1</sub> + a<sub>2</sub>⋅P<sub>2</sub> + ... + a<sub>u</sub>⋅P<sub>u</sub>''.
-• ''Q<sub>i</sub>'' is the tweaked public key after the ''i''-th execution of ''ApplyTweak'' for ''1 &le; i &le; v''. It holds that
+• ''Q<sub>i</sub>'' is the tweaked aggregate public key after the ''i''-th execution of ''ApplyTweak'' for ''1 &le; i &le; v''. It holds that
     ''Q<sub>i</sub> = f(i-1) + t<sub>i</sub>⋅G'' for ''i = 1, ..., v'' where
         ''f(i-1) := with_even_y(Q<sub>i-1</sub>)'' if ''is_xonly_t<sub>i</sub>'' and
         ''f(i-1) := Q<sub>i-1</sub>'' otherwise.
@@ -711,7 +711,7 @@ Then we have
 
 Intuitively, ''gacc<sub>i</sub>'' tracks accumulated sign flipping and ''tacc<sub>i</sub>'' tracks the accumulated tweak value after applying the first ''i'' individual tweaks. Additionally, ''g<sub>v</sub>'' indicates whether ''Q<sub>v</sub>'' needed to be negated to produce the final X-only result. Thus, signer ''i'' multiplies its secret key ''d<sub>i</sub>' '' with ''g<sub>v</sub>⋅gacc<sub>v</sub>'' in the ''[[#Sign negation|Sign]]'' algorithm.
 
-==== Negation Of The Public Key When Partially Verifying ====
+==== Negation Of The Individual Public Key When Partially Verifying ====
 
 <poem>
 As explained in [[#negation-of-the-secret-key-when-signing|Negation Of The Secret Key When Signing]] the signer uses a possibly negated secret key
@@ -783,7 +783,7 @@ The <code>PATCH</code> version is incremented for other changes that are notewor
 ** Add explicit ''IndividualPubkey'' algorithm.
 * '''1.0.0-rc.2''' (2022-10-28):
 ** Fix vulnerability that can occur in certain unusual scenarios (see [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html bitcoin-dev mailing list]: Add mandatory ''pk'' argument to ''NonceGen'', append ''pk'' to ''secnonce'' and check in ''Sign'' that the ''pk'' in ''secnonce'' matches. Update test vectors.
-** Make sure that signer's key is in list of input public keys by adding failure case to ''GetSessionKeyAggCoeff'' and add test vectors.
+** Make sure that signer's key is in list of individual public keys by adding failure case to ''GetSessionKeyAggCoeff'' and add test vectors.
 * '''1.0.0-rc.1''' (2022-10-03): Submit draft BIP to the BIPs repository
 * '''0.8.6''' (2022-09-15): Clarify that implementations do not need to support every feature and add a test vector for signing with a tweaked key
 * '''0.8.5''' (2022-09-05): Rename some functions to improve clarity.
@@ -791,7 +791,7 @@ The <code>PATCH</code> version is incremented for other changes that are notewor
 * '''0.8.3''' (2022-09-01): Overwrite ''secnonce'' in ''sign'' reference implementation to help prevent accidental reuse and add test vector for invalid ''secnonce''.
 * '''0.8.2''' (2022-08-30): Fix ''KeySort'' input length and add test vectors
 * '''0.8.1''' (2022-08-26): Add ''DeterministicSign'' algorithm
-* '''0.8.0''' (2022-08-26): Switch from X-only to plain public key inputs. This requires updating a large portion of the test vectors.
+* '''0.8.0''' (2022-08-26): Switch from X-only to plain public key for individual public keys. This requires updating a large portion of the test vectors.
 * '''0.7.2''' (2022-08-17): Add ''NonceGen'' and ''Sign/PartialSigVerify'' test vectors for messages longer than 32 bytes.
 * '''0.7.1''' (2022-08-10): Extract test vectors into separate JSON file.
 * '''0.7.0''' (2022-07-31): Change ''NonceGen'' such that output when message is not present is different from when message is present but has length 0.

--- a/bip-musig2.mediawiki
+++ b/bip-musig2.mediawiki
@@ -107,9 +107,9 @@ Plain public keys are byte strings of length 33 (often called ''compressed'' for
 In contrast, X-only public keys are 32-byte strings defined in [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki BIP340].
 
 The individual public keys of signers as input to the key aggregation algorithm ''KeyAgg'' (and to ''GetSessionValues'' and ''PartialSigVerify'') are plain public keys.
-The output of ''KeyAgg'' is a [[#keygen-context|KeyGen Context]] which stores information required for tweaking the aggregate public key (see [[#tweaking-the-aggregate-public-key|below]]),
+The output of ''KeyAgg'' is a [[#keyagg-context|KeyAgg Context]] which stores information required for tweaking the aggregate public key (see [[#tweaking-the-aggregate-public-key|below]]),
 and it can be used to produce an X-only aggregate public key, or a plain aggregate public key.
-In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyGen Context.
+In order to obtain an X-only public key compatible with BIP340 verification, implementations call the ''GetXonlyPubkey'' function with the KeyAgg Context.
 To get the plain aggregate public key, which is required for some applications of [[#tweaking-the-aggregate-public-key|tweaking]], implementations call ''GetPlainPubkey'' instead.
 
 The aggregate public key produced by ''KeyAgg'' (regardless of the type) depends on the order of the individual public keys.
@@ -184,8 +184,8 @@ However, if ''PartialSigVerify'' succeeds for all partial signatures then ''Part
 === Tweaking the Aggregate Public Key ===
 
 The aggregate public key can be ''tweaked'', which modifies the key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
-In order to apply a tweak, the KeyGen Context output by ''KeyAgg'' is provided to the ''ApplyTweak'' algorithm with the ''is_xonly_t'' argument set to false for plain tweaking and true for X-only tweaking.
-The resulting KeyGen Context can be used to apply another tweak with ''ApplyTweak'' or obtain the aggregate public key with ''GetXonlyPubkey'' or ''GetPlainPubkey''.
+In order to apply a tweak, the KeyAgg Context output by ''KeyAgg'' is provided to the ''ApplyTweak'' algorithm with the ''is_xonly_t'' argument set to false for plain tweaking and true for X-only tweaking.
+The resulting KeyAgg Context can be used to apply another tweak with ''ApplyTweak'' or obtain the aggregate public key with ''GetXonlyPubkey'' or ''GetPlainPubkey''.
 
 In addition to individual public keys, the ''KeyAgg'' algorithm accepts tweaks, which modify the aggregate public key as defined in the [[#tweaking-definition|Tweaking Definition]] subsection.
 For example, if ''KeyAgg'' is run with ''v = 2'', ''is_xonly_t<sub>1</sub> = false'', ''is_xonly_t<sub>2</sub> = true'', then the aggregate key is first plain tweaked with ''tweak<sub>1</sub>'' and then X-only tweaked with ''tweak<sub>2</sub>''.
@@ -202,7 +202,7 @@ Plain tweaking can be used to derive child public keys from an aggregate public 
 On the other hand, X-only tweaking is required for Taproot tweaking per [https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341].
 A Taproot-tweaked public key commits to a ''script path'', allowing users to create transaction outputs that are spendable either with a MuSig2 multi-signature or by providing inputs that satisfy the script path.
 Script path spends require a control block that contains a parity bit for the tweaked X-only public key.
-The bit can be obtained with ''GetPlainPubkey(keygen_ctx)[0] & 1''.
+The bit can be obtained with ''GetPlainPubkey(keyagg_ctx)[0] & 1''.
 
 == Algorithms ==
 
@@ -261,24 +261,24 @@ Algorithm ''IndividualPubkey(sk)'':<ref>The ''IndividualPubkey'' algorithm match
 * Return ''cbytes(d'⋅G)''.
 </div>
 
-==== KeyGen Context ====
+==== KeyAgg Context ====
 
-The KeyGen Context is a data structure consisting of the following elements:
+The KeyAgg Context is a data structure consisting of the following elements:
 * The point ''Q'' representing the potentially tweaked aggregate public key: an elliptic curve point
 * The accumulated tweak ''tacc'': an integer with ''0 &le; tacc < n''
 * The value ''gacc'' : 1 or -1 mod n
 
-We write "Let ''(Q, gacc, tacc) = keygen_ctx''" to assign names to the elements of a KeyGen Context.
+We write "Let ''(Q, gacc, tacc) = keyagg_ctx''" to assign names to the elements of a KeyAgg Context.
 
 <div>
-Algorithm ''GetXonlyPubkey(keygen_ctx)'':
-* Let ''(Q, _, _) = keygen_ctx''
+Algorithm ''GetXonlyPubkey(keyagg_ctx)'':
+* Let ''(Q, _, _) = keyagg_ctx''
 * Return ''xbytes(Q)''
 </div>
 
 <div>
-Algorithm ''GetPlainPubkey(keygen_ctx)'':
-* Let ''(Q, _, _) = keygen_ctx''
+Algorithm ''GetPlainPubkey(keyagg_ctx)'':
+* Let ''(Q, _, _) = keyagg_ctx''
 * Return ''cbytes(Q)''
 </div>
 
@@ -307,7 +307,7 @@ Algorithm ''KeyAgg(pk<sub>1..u</sub>)'':
 * Fail if ''is_infinite(Q)''.
 * Let ''gacc = 1''
 * Let ''tacc = 0''
-* Return ''keygen_ctx = (Q, gacc, tacc)''.
+* Return ''keyagg_ctx = (Q, gacc, tacc)''.
 </div>
 
 <div>
@@ -340,12 +340,12 @@ Internal Algorithm ''KeyAggCoeffInternal(pk<sub>1..u</sub>, pk', pk2)'':
 ==== Applying Tweaks ====
 
 <div>
-Algorithm ''ApplyTweak(keygen_ctx, tweak, is_xonly_t)'':
+Algorithm ''ApplyTweak(keyagg_ctx, tweak, is_xonly_t)'':
 * Inputs:
-** The ''keygen_ctx'': a [[#keygen-context|KeyGen Context]] data structure
+** The ''keyagg_ctx'': a [[#keyagg-context|KeyAgg Context]] data structure
 ** The ''tweak'': a 32-byte array
 ** The tweak mode ''is_xonly_t'': a boolean
-* Let ''(Q, gacc, tacc) = keygen_ctx''
+* Let ''(Q, gacc, tacc) = keyagg_ctx''
 * If ''is_xonly_t'' and ''not has_even_y(Q)'':
 ** Let ''g = -1 mod n''
 * Else:
@@ -355,7 +355,7 @@ Algorithm ''ApplyTweak(keygen_ctx, tweak, is_xonly_t)'':
 ** Fail if ''is_infinite(Q')''
 * Let ''gacc' = g⋅gacc mod n''
 * Let ''tacc' = t + g⋅tacc mod n''
-* Return ''keygen_ctx' = (Q', gacc', tacc')''
+* Return ''keyagg_ctx' = (Q', gacc', tacc')''
 </div>
 
 === Nonce Generation ===
@@ -419,10 +419,10 @@ We write "Let ''(aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xon
 <div>
 Algorithm ''GetSessionValues(session_ctx)'':
 * Let ''(aggnonce, u, pk<sub>1..u</sub>, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m) = session_ctx''
-* Let ''keygen_ctx<sub>0</sub> = KeyAgg(pk<sub>1..u</sub>)''; fail if that fails
+* Let ''keyagg_ctx<sub>0</sub> = KeyAgg(pk<sub>1..u</sub>)''; fail if that fails
 * For ''i = 1 .. v'':
-** Let ''keygen_ctx<sub>i</sub> = ApplyTweak(keygen_ctx<sub>i-1</sub>, tweak<sub>i</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
-* Let ''(Q, gacc, tacc) = keygen_ctx<sub>v</sub>''
+** Let ''keyagg_ctx<sub>i</sub> = ApplyTweak(keyagg_ctx<sub>i-1</sub>, tweak<sub>i</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
+* Let ''(Q, gacc, tacc) = keyagg_ctx<sub>v</sub>''
 * Let ''b = int(hash<sub>MuSig/noncecoef</sub>(aggnonce || xbytes(Q) || m)) mod n''
 * Let ''R<sub>1</sub> = cpoint_ext(aggnonce[0:33]), R<sub>2</sub> = cpoint_ext(aggnonce[33:66])''; fail if that fails and blame nonce aggregator for invalid ''aggnonce''.
 * Let ''R' = R<sub>1</sub> + b⋅R<sub>2</sub>''
@@ -615,10 +615,10 @@ Algorithm ''DeterministicSign(sk, aggothernonce, pk<sub>1..u</sub>, tweak<sub>1.
 ** Let ''sk' '' be the byte-wise xor of ''sk'' and ''hash<sub>MuSig/aux</sub>(rand)''
 * Else:
 ** Let ''sk' = sk''
-* Let ''keygen_ctx<sub>0</sub> = KeyAgg(pk<sub>1..u</sub>)''; fail if that fails
+* Let ''keyagg_ctx<sub>0</sub> = KeyAgg(pk<sub>1..u</sub>)''; fail if that fails
 * For ''i = 1 .. v'':
-** Let ''keygen_ctx<sub>i</sub> = ApplyTweak(keygen_ctx<sub>i-1</sub>, tweak<sub>i</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
-* Let ''aggpk = GetPubkey(keygen_ctx<sub>v</sub>)''
+** Let ''keyagg_ctx<sub>i</sub> = ApplyTweak(keyagg_ctx<sub>i-1</sub>, tweak<sub>i</sub>, is_xonly_t<sub>i</sub>)''; fail if that fails
+* Let ''aggpk = GetPubkey(keyagg_ctx<sub>v</sub>)''
 * Let ''k<sub>i</sub> = int(hash<sub>MuSig/deterministic/nonce</sub>(sk' || aggothernonce || aggpk || bytes(8, len(m)) || m || bytes(1, i - 1))) mod n'' for ''i = 1,2''
 * Fail if ''k<sub>1</sub> = 0'' or ''k<sub>2</sub> = 0''
 * Let ''R<sub>⁎,1</sub> = k<sub>1</sub>⋅G, R<sub>⁎,2</sub> = k<sub>2</sub>⋅G''
@@ -781,6 +781,7 @@ The <code>PATCH</code> version is incremented for other changes that are notewor
 ** Fix invalid length of a ''pubnonce'' in the ''PartialSigVerify'' test vectors.
 ** Improve ''KeySort'' test vector.
 ** Add explicit ''IndividualPubkey'' algorithm.
+** Rename KeyGen Context to KeyAgg Context.
 * '''1.0.0-rc.2''' (2022-10-28):
 ** Fix vulnerability that can occur in certain unusual scenarios (see [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/021000.html bitcoin-dev mailing list]: Add mandatory ''pk'' argument to ''NonceGen'', append ''pk'' to ''secnonce'' and check in ''Sign'' that the ''pk'' in ''secnonce'' matches. Update test vectors.
 ** Make sure that signer's key is in list of individual public keys by adding failure case to ''GetSessionKeyAggCoeff'' and add test vectors.


### PR DESCRIPTION
On top of #84.

This is more natural because
  - the ctx is output by KeyAgg
  - we now speak of "tweaking aggregate public keys" consistently
  - we now use the term "key generation" for generation of individual keys